### PR TITLE
Modify tank mass so that structure is less and tank is more

### DIFF
--- a/GameData/B9PartSwitch/B9PartSwitch.cfg
+++ b/GameData/B9PartSwitch/B9PartSwitch.cfg
@@ -1,15 +1,15 @@
 // Structural values (should be set by user)
 // Rocket
-//   Mass = 0.0005
+//   Mass = 0.00025
 //   Cost = 0.25
 // Spaceplane (re-entry shielded, maxTemp > 2000)
-//   Mass = 0.000625
+//   Mass = 0.000375
 //   Cost = 0.375
 
 B9_TANK_TYPE
 {
 	name = LiquidFuel
-	tankMass = 0.0001
+	tankMass = 0.00035
 	tankCost = 0.375
 	RESOURCE
 	{
@@ -21,7 +21,7 @@ B9_TANK_TYPE
 B9_TANK_TYPE
 {
 	name = LFO
-	tankMass = 0.000125
+	tankMass = 0.000375
 	tankCost = 0.25
 	
 	RESOURCE
@@ -39,7 +39,7 @@ B9_TANK_TYPE
 B9_TANK_TYPE
 {
 	name = MonoPropellant
-	tankMass = 0.0004
+	tankMass = 0.00065
 	tankCost = 0.75
 	
 	RESOURCE
@@ -52,7 +52,7 @@ B9_TANK_TYPE
 B9_TANK_TYPE
 {
 	name = Battery
-	tankMass = 0.0009
+	tankMass = 0.00115
 	tankCost = 15.0
 	
 	RESOURCE


### PR DESCRIPTION
Based on mk1 structural fuselage (really only point of reference)

AFAIK only B9 uses these tank types at present, to should be safe to
change
