### PR TITLE
Put constants in a nested class

### DIFF
--- a/B9PartSwitch/PartSwitch/ModuleB9PartInfo.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartInfo.cs
@@ -5,23 +5,26 @@ namespace B9PartSwitch
 {
     public class ModuleB9PartInfo : PartModule
     {
-        public const string DryMassGUIString = "Mass (Dry)";
-        public const string MassGUIString = "Mass";
+        public static class Constants
+        {
+            public const string DryMassGUIString = "Mass (Dry)";
+            public const string MassGUIString = "Mass";
 
-        public const string DryCostGUIString = "Cost (Dry)";
-        public const string CostGUIString = "Cost";
+            public const string DryCostGUIString = "Cost (Dry)";
+            public const string CostGUIString = "Cost";
+        }
 
         [UI_Toggle(enabledText = "Enabled", disabledText = "Hidden")]
         [KSPField(guiActiveEditor = true, guiName = "Part Info")]
         public bool showInfo = false;
 
-        [KSPField(guiName = DryMassGUIString, guiFormat = "N3", guiUnits = "t")]
+        [KSPField(guiName = Constants.DryMassGUIString, guiFormat = "N3", guiUnits = "t")]
         public float dryMass = 0f;
 
         [KSPField(guiName = "Mass (Wet)", guiFormat = "N3", guiUnits = "t")]
         public float wetMass = 0f;
 
-        [KSPField(guiName = "Cost (Dry)", guiFormat = "N2")]
+        [KSPField(guiName = Constants.DryCostGUIString, guiFormat = "N2")]
         public float dryCost = 0f;
 
         [KSPField(guiName = "Cost (Wet)", guiFormat = "N2")]
@@ -67,12 +70,12 @@ namespace B9PartSwitch
 
             var dryMassField = Fields[nameof(dryMass)];
             dryMassField.guiActiveEditor = showInfo && showMass;
-            dryMassField.guiName = hasResources ? DryMassGUIString : MassGUIString;
+            dryMassField.guiName = hasResources ? Constants.DryMassGUIString : Constants.MassGUIString;
             Fields[nameof(wetMass)].guiActiveEditor = showInfo && showMass && hasResources;
 
             var dryCostField = Fields[nameof(dryCost)];
             dryCostField.guiActiveEditor = showInfo && showCost;
-            dryCostField.guiName = hasResources ? DryCostGUIString : CostGUIString;
+            dryCostField.guiName = hasResources ? Constants.DryCostGUIString : Constants.CostGUIString;
             Fields[nameof(wetCost)].guiActiveEditor = showInfo && showCost && hasResources;
 
             Fields[nameof(maxTemp)].guiActiveEditor = showInfo && switcherModules.Any(module => module.MaxTempManaged);


### PR DESCRIPTION
KSP explodes when you have const fields on a PartModule because it tries
to copy fields from one object to another on the root part without
checking the fields first.

http://bugs.kerbalspaceprogram.com/issues/9865