### PR TITLE
Reference KSP DLLs rather than moving them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install:
   - build_script/install/install_ksp_dlls.sh
   - nuget restore ${TRAVIS_SOLUTION}
 script:
-  - xbuild /p:Configuration=Release ${TRAVIS_SOLUTION}
+  - xbuild /p:Configuration=Release /p:ReferencePath="${KSP_DLL_PATH}" ${TRAVIS_SOLUTION}
   - build_script/script/avc_version.rb
   - build_script/script/make_zip.sh
 before_deploy:
@@ -32,5 +32,6 @@ env:
     - PROJECT_NAME="B9PartSwitch"
     - PROJECT_DIR="B9PartSwitch"
     - KSP_VERSION="$(cat KSP_VERSION)"
+    - KSP_DLL_PATH="${TRAVIS_BUILD_DIR}/KSP_DLLs/${KSP_VERSION}"
 notifications:
   email: false

--- a/build_script/install/install_ksp_dlls.sh
+++ b/build_script/install/install_ksp_dlls.sh
@@ -2,5 +2,3 @@
 
 wget --no-check-certificate --quiet "https://drive.google.com/uc?export=download&id=${GDRIVE_DLL_PACKAGE_ID}" -O KSP_DLLs.zip
 unzip -P ${DLL_PACKAGE_ZIP_PASSPHRASE} KSP_DLLs.zip
-mkdir -v -p ${PROJECT_DIR}/bin/Release/
-cp -v KSP_DLLs/${KSP_VERSION}/* ${PROJECT_DIR}/bin/Release/


### PR DESCRIPTION
Easier to deal with this way, and supports multiple projects