### PR TITLE
Unify AssemblyInfo on Windows and unix-like

### DIFF
--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -79,8 +79,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent Condition=" '$(OS)' == 'Unix' ">(cd ../../.. ; PROJECT_NAME='$(MSBuildProjectName)' build_script/script/assembly_info.rb)</PreBuildEvent>
-    <PreBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">cmd /c "cd ../../.. &amp; SET PROJECT_NAME=$(MSBuildProjectName) &amp; ruby build_script\script\assembly_info.rb"</PreBuildEvent>
+    <PreBuildEvent>sh -c "cd ../../../ &amp;&amp; build_script/script/assembly_info.rb '$(MSBuildProjectName)'"</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/build_script/script/assembly_info.rb
+++ b/build_script/script/assembly_info.rb
@@ -2,8 +2,17 @@
 
 require_relative '../version/tag_version'
 
+project_name = ARGV[0]
+
+if project_name.nil? || project_name.empty?
+  raise 'No project name specified!'
+end
+
+project_name = project_name.strip
+
 version = get_tag_version
-project_name = ENV['PROJECT_NAME'].strip
+
+puts "Generating AssemblyInfo for project '#{project_name}' with version #{version.full_version}"
 
 attributes_data = {
   'AssemblyVersion' 	  => ["\"#{version.full_version}\""],
@@ -20,9 +29,11 @@ assembly_info_elements = [assembly_info_in] + attributes + [nil]
 assembly_info_out = assembly_info_elements.join("\n")
 
 assembly_info_dir = File.join(project_name, 'Properties')
-
-puts Dir.pwd
-puts assembly_info_dir
+assembly_info_file = File.join(assembly_info_dir, 'AssemblyInfo.cs')
 
 Dir.mkdir(assembly_info_dir) unless Dir.exists? assembly_info_dir
-File.open(File.join(assembly_info_dir, 'AssemblyInfo.cs'), 'w+') { |f| f.write(assembly_info_out) }
+
+puts "Writing AssemblyInfo to '#{assembly_info_file}'"
+File.open(assembly_info_file, 'w+') { |f| f.write(assembly_info_out) }
+
+puts "Done generating AssemblyInfo"


### PR DESCRIPTION
Windows needs sh command somewhere

Also add better logging to AssemblyInfo generation