### PR TITLE
Add transform disabling module

### DIFF
--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Fishbones\NodeDataMappers\ValueListMapperBuilder.cs" />
     <Compile Include="Fishbones\NodeDataMappers\ValueScalarMapperBuilder.cs" />
     <Compile Include="Fishbones\UseParser.cs" />
+    <Compile Include="ModuleB9DisableTransform.cs" />
     <Compile Include="PartSwitch\ModuleB9PartInfo.cs" />
     <Compile Include="PartSwitch\PartSubtypeContext.cs" />
     <Compile Include="PartSwitch\SubtypePartField.cs" />

--- a/B9PartSwitch/ModuleB9DisableTransform.cs
+++ b/B9PartSwitch/ModuleB9DisableTransform.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace B9PartSwitch
+{
+    public class ModuleB9DisableTransform : PartModule
+    {
+        public override void OnLoad(ConfigNode node)
+        {
+            base.OnLoad(node);
+
+            foreach (string transformName in node.GetValues("transform"))
+            {
+                Transform[] transforms = part.FindModelTransforms(transformName);
+
+                if (transforms.Length == 0)
+                {
+                    this.LogError($"No transforms named '{transformName}' found in model");
+                    continue;
+                }
+
+                foreach (Transform transform in transforms)
+                {
+                    transform.gameObject.SetActive(false);
+                }
+            }
+
+            part.RemoveModule(this);
+        }
+    }
+}


### PR DESCRIPTION
This will be used by old wheels in B9 once they are converted to KSPWheel - there is a bounds collider that needs to be removed.