### PR TITLE
Add virtual mod provides

### DIFF
--- a/NetKAN/B9PartSwitch.netkan
+++ b/NetKAN/B9PartSwitch.netkan
@@ -14,6 +14,8 @@
   "depends" : [
     { "name" : "ModuleManager" }
   ],
+    "provides": [ "DeadskinsMeshSwitch" ],
+    
     "install": [
         {
             "find"       : "B9PartSwitch",


### PR DESCRIPTION
A future DeadSkins release is going to change from their current texture switching methods to a mesh switching method which can be achieved by B9PartSwitch. Adding this provide to B9PartSwitch will get things ready for that future change.