### PR TITLE
Fix order that subtypes are (de)activated for icon

### DIFF
--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -354,11 +354,11 @@ namespace B9PartSwitch
             // This will deactivate objects on non-active subtypes before the part icon is created, avoiding a visual mess
             foreach (PartSubtype subtype in subtypes)
             {
-                if (subtype == CurrentSubtype)
-                    subtype.ActivateForIcon();
-                else
-                    subtype.DeactivateForIcon();
+                if (subtype == CurrentSubtype) continue;
+                subtype.DeactivateForIcon();
             }
+
+            CurrentSubtype.ActivateForIcon();
         }
 
         private void SetupSubtypes()


### PR DESCRIPTION
The active subtype should be done last, otherwise transforms that should
be enabled might not be