### PR TITLE
Fix transform in a TEXTURE node lookin for renderers in children

### DIFF
--- a/B9PartSwitch/PartSwitch/TextureSwitchInfo.cs
+++ b/B9PartSwitch/PartSwitch/TextureSwitchInfo.cs
@@ -126,7 +126,7 @@ namespace B9PartSwitch
                 foreach (Transform transform in part.GetModelTransforms(transformName))
                 {
                     foundTransform = true;
-                    Renderer[] transformRenderers = transform.GetComponentsInChildren<Renderer>();
+                    Renderer[] transformRenderers = transform.GetComponents<Renderer>();
 
                     if (transformRenderers.Length == 0)
                     {


### PR DESCRIPTION
It should only look at the current GameObject for `transform`,
`baseTransform` is used if you also want children