### PR TITLE
Deactivate texture switches before re-initializing

### DIFF
--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -362,6 +362,12 @@ namespace B9PartSwitch
             if (parent == null)
                 throw new InvalidOperationException("Parent has not been set");
 
+            // Ensure that textures are reset before doing this
+            foreach(TextureReplacement tr in textureReplacements)
+            {
+                tr.Deactivate();
+            }
+
             textureReplacements.Clear();
 
             foreach (TextureSwitchInfo info in textureSwitches)


### PR DESCRIPTION
If a part up the hierarchy gets its drag cubes rendered when loading a
craft, the texture switches will be activated by the process of creating
the drag cube clone (deactivated before the clone and then activated
after), then Start is called on this part which re-initializes the
texture switches.  The original information is lost and the texture
switch is now locked in.