### PR TITLE
Revert hack fix for map object disappearing

### DIFF
--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -592,14 +592,7 @@ namespace B9PartSwitch
                 yield return null;
                 yield return null;
 
-                // FIXME - This is a hack to get around the fact that KSP will remove the mapObject when rendering drag cubes
-                // This will hopefully be fixed in KSP 1.3.1
-                MapObject mapObject = vessel.mapObject;
-                vessel.mapObject = null;
-
-                yield return RenderProceduralDragCubes();
-
-                vessel.mapObject = mapObject;
+                RenderProceduralDragCubes();
             }
 
             StartCoroutine(UpdateDragCubesForRootPartInFlightCoroutine());
@@ -638,10 +631,10 @@ namespace B9PartSwitch
             return ReferenceEquals(this, lastModule);
         }
 
-        private Coroutine RenderProceduralDragCubes()
+        private void RenderProceduralDragCubes()
         {
             part.DragCubes.ClearCubes();
-            return StartCoroutine(DragCubeSystem.Instance.SetupDragCubeCoroutine(part, null));
+            StartCoroutine(DragCubeSystem.Instance.SetupDragCubeCoroutine(part, null));
         }
 
         private void UpdateVolumeFromChildren()


### PR DESCRIPTION
This workaround was introduced in 8c8fe28 and is fixed in KSP 1.4.3

Resolves #45