### PR TITLE
Fix ModuleJettison fairing disappearing

### DIFF
--- a/B9PartSwitch/Extensions/PartExtensions.cs
+++ b/B9PartSwitch/Extensions/PartExtensions.cs
@@ -111,6 +111,26 @@ namespace B9PartSwitch
             return part.GetModelRoot().GetChildrenNamedRecursive(name);
         }
 
+        public static void FixModuleJettison(this Part part)
+        {
+            if (!HighLogic.LoadedSceneIsFlight) return;
+
+            foreach (ModuleJettison module in part.Modules.OfType<ModuleJettison>())
+            {
+                if (
+                    !module.useMultipleDragCubes ||
+                    !module.isFairing ||
+                    !module.decoupleEnabled ||
+                    module.isJettisoned ||
+                    module.jettisonTransform == null ||
+                    module.jettisonTransform.root == part.gameObject.transform.root
+                ) continue;
+                Object.Instantiate(module.jettisonTransform, module.jettisonTransform.parent);
+                module.jettisonTransform.parent = part.GetModelRoot();
+                module.jettisonTransform.gameObject.SetActive(false);
+            }
+        }
+
         public static void LogInfo(this Part part, object message) => Debug.Log($"[Part {part.name}] {message}");
         public static void LogWarning(this Part part, object message) => Debug.LogWarning($"[WARNING] [Part {part.name}] {message}");
         public static void LogError(this Part part, object message) => Debug.LogError($"[ERROR] [Part {part.name}] {message}");

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -128,7 +128,9 @@ namespace B9PartSwitch
         {
             base.OnLoadInstance(node);
 
+            InitializeSubtypes();
             FindBestSubtype(node);
+            UpdateOnLoad();
         }
 
         public override void OnIconCreate()
@@ -158,7 +160,9 @@ namespace B9PartSwitch
         {
             CheckOtherSwitchers();
             CheckOtherModules();
-            
+
+            if (affectDragCubes) part.FixModuleJettison();
+
             UpdateOnStart();
         }
 
@@ -418,6 +422,14 @@ namespace B9PartSwitch
         {
             BaseEvent switchSubtypeEvent = Events[nameof(ShowSubtypesWindow)];
             switchSubtypeEvent.guiActive = switchInFlight && subtypes.Any(s => s != CurrentSubtype && s.allowSwitchInFlight);
+        }
+
+        private void UpdateOnLoad()
+        {
+            subtypes.ForEach(subtype => subtype.DeactivateOnStart());
+            RemoveUnusedResources();
+            UpdateVolumeFromChildren();
+            CurrentSubtype.ActivateOnStart();
         }
 
         private void UpdateOnStart()


### PR DESCRIPTION
Create a copy of the fairing object on the attached part, then move the real one back to the actual part and hide it.  The model ends up in the same state as when the part starts with the fairing already jettisoned.

Resolves #85