### PR TITLE
use ONEZONE_IA s3 storage for dev builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ deploy:
     access_key_id: ${S3_ACCESS_KEY_ID}
     secret_access_key: ${S3_SECRET_ACCESS_KEY}
     bucket: blowfish-ksp-b9partswitch-dev-builds
+    storage_class: ONEZONE_IA
     local_dir: deploy/s3/
     upload-dir: ${TRAVIS_BRANCH}
     on:


### PR DESCRIPTION
These rarely need to be accessed and can be rebuilt if needed.  High availability is not needed.

That's Infrequent Access - Single Availability Zone