### PR TITLE
Better exception handling

### DIFF
--- a/B9PartSwitch/CustomPartModule.cs
+++ b/B9PartSwitch/CustomPartModule.cs
@@ -1,4 +1,5 @@
-﻿using UniLinq;
+using System;
+using UniLinq;
 using UnityEngine;
 using B9PartSwitch.Fishbones;
 using B9PartSwitch.Fishbones.Context;
@@ -74,7 +75,17 @@ namespace B9PartSwitch
             bool loadingPrefab = part.partInfo.IsNull() || node.name == CURRENT_UPGRADE;
             Operation operation = loadingPrefab ? Operation.LoadPrefab : Operation.LoadInstance;
             OperationContext context = new OperationContext(operation, this);
-            this.LoadFields(node, context);
+
+            try
+            {
+                this.LoadFields(node, context);
+            }
+            catch (Exception ex)
+            {
+                Exception ex2 = new Exception($"Fatal exception while loading fields on module {this}", ex);
+                FatalErrorHandler.HandleFatalError(ex2);
+                throw ex2;
+            }
 
             if (loadingPrefab)
                 OnLoadPrefab(node);
@@ -94,7 +105,17 @@ namespace B9PartSwitch
             base.OnSave(node);
 
             OperationContext context = new OperationContext(Operation.Save, this);
-            this.SaveFields(node, context);
+
+            try
+            {
+                this.SaveFields(node, context);
+            }
+            catch (Exception ex)
+            {
+                Exception ex2 = new Exception($"Fatal exception while saving fields on module {this}", ex);
+                FatalErrorHandler.HandleFatalError(ex2);
+                throw ex2;
+            }
         }
 
         #endregion

--- a/B9PartSwitch/FatalErrorHandler.cs
+++ b/B9PartSwitch/FatalErrorHandler.cs
@@ -4,28 +4,24 @@ using UnityEngine;
 
 namespace B9PartSwitch
 {
-    public class FatalException : Exception
-    {
-        public FatalException(string message, Exception innerException) : base(message, innerException) { }
-    }
-
-    public class HandledFatalException : Exception
-    {
-        public HandledFatalException(FatalException exception) : base(exception.Message, exception.InnerException) { }
-    }
-
     public static class FatalErrorHandler
     {
         private const int MAX_MESSAGE_COUNT = 10;
         private static PopupDialog dialog;
         private static List<string> allMessages = new List<string>();
 
-        public static void HandleFatalError(FatalException exception)
+        public static void HandleFatalError(Exception exception)
         {
             try
             {
-                string message = exception.InnerException?.Message;
-
+                string message = exception.Message;
+                Exception innerException = exception.InnerException;
+                while (innerException != null)
+                {
+                    message += "\n  ";
+                    message += innerException.Message;
+                    innerException = innerException.InnerException;
+                }
                 UpsertDialog(message);
             }
             catch (Exception ex)
@@ -34,8 +30,6 @@ namespace B9PartSwitch
                 Debug.LogException(ex);
                 Application.Quit();
             }
-
-            throw new HandledFatalException(exception);
         }
 
         private static void UpsertDialog(string message)

--- a/B9PartSwitch/Fishbones/FieldWrappers/FieldWrapper.cs
+++ b/B9PartSwitch/Fishbones/FieldWrappers/FieldWrapper.cs
@@ -28,6 +28,7 @@ namespace B9PartSwitch.Fishbones.FieldWrappers
             field.SetValue(subject, value);
         }
 
+        public string Name => field.Name;
         public Type FieldType => field.FieldType;
         public MemberInfo MemberInfo => field;
     }

--- a/B9PartSwitch/Fishbones/FieldWrappers/IFieldWrapper.cs
+++ b/B9PartSwitch/Fishbones/FieldWrappers/IFieldWrapper.cs
@@ -7,6 +7,7 @@ namespace B9PartSwitch.Fishbones.FieldWrappers
     {
         object GetValue(object subject);
         void SetValue(object subject, object value);
+        string Name { get; }
         Type FieldType { get; }
         MemberInfo MemberInfo { get; }
     }

--- a/B9PartSwitch/Fishbones/FieldWrappers/PropertyWrapper.cs
+++ b/B9PartSwitch/Fishbones/FieldWrappers/PropertyWrapper.cs
@@ -35,6 +35,7 @@ namespace B9PartSwitch.Fishbones.FieldWrappers
             setMethod.Invoke(subject, new[] { value } );
         }
 
+        public string Name => property.Name;
         public Type FieldType => property.PropertyType;
         public MemberInfo MemberInfo => property;
     }

--- a/B9PartSwitch/Fishbones/NodeDataField.cs
+++ b/B9PartSwitch/Fishbones/NodeDataField.cs
@@ -6,6 +6,8 @@ namespace B9PartSwitch.Fishbones
 {
     public interface INodeDataField
     {
+        string Name { get; }
+
         void Load(ConfigNode node, OperationContext context);
         void Save(ConfigNode node, OperationContext context);
     }
@@ -14,6 +16,8 @@ namespace B9PartSwitch.Fishbones
     {
         public readonly IFieldWrapper field;
         public readonly IOperaitonManager operationManager;
+
+        public string Name => field.Name;
 
         public NodeDataField(IFieldWrapper field, IOperaitonManager operationManager)
         {

--- a/B9PartSwitch/Fishbones/NodeDataList.cs
+++ b/B9PartSwitch/Fishbones/NodeDataList.cs
@@ -6,7 +6,7 @@ namespace B9PartSwitch.Fishbones
 {
     public class NodeDataList
     {
-        private INodeDataField[] fields;
+        private readonly INodeDataField[] fields;
 
         public NodeDataList(params INodeDataField[] fields)
         {

--- a/B9PartSwitch/Fishbones/NodeDataList.cs
+++ b/B9PartSwitch/Fishbones/NodeDataList.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine;
 using B9PartSwitch.Fishbones.Context;
 
 namespace B9PartSwitch.Fishbones

--- a/B9PartSwitch/Fishbones/NodeDataList.cs
+++ b/B9PartSwitch/Fishbones/NodeDataList.cs
@@ -28,20 +28,16 @@ namespace B9PartSwitch.Fishbones
             node.ThrowIfNullArgument(nameof(node));
             context.ThrowIfNullArgument(nameof(context));
 
-            try
+            foreach (INodeDataField field in fields)
             {
-                foreach (INodeDataField field in fields)
+                try
                 {
                     field.Load(node, context);
                 }
-            }
-            catch (HandledFatalException)
-            {
-                throw;
-            }
-            catch (Exception e)
-            {
-                FatalErrorHandler.HandleFatalError(new FatalException($"Fatal exception while attempting to load fields for {context.Subject?.GetType()}", e));
+                catch(Exception ex)
+                {
+                    throw new Exception($"Exception while loading field {field.Name} on type {context.Subject?.GetType()}", ex);
+                }
             }
         }
 
@@ -52,7 +48,14 @@ namespace B9PartSwitch.Fishbones
 
             foreach (INodeDataField field in fields)
             {
-                field.Save(node, context);
+                try
+                {
+                    field.Save(node, context);
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception($"Exception while saving field {field.Name} on type {context.Subject?.GetType()}", ex);
+                }
             }
         }
     }

--- a/B9PartSwitch/Fishbones/NodeDataListLibrary.cs
+++ b/B9PartSwitch/Fishbones/NodeDataListLibrary.cs
@@ -23,13 +23,11 @@ namespace B9PartSwitch.Fishbones
                 NodeDataListBuilder builder = new NodeDataListBuilder(type);
                 list = builder.CreateList();
             }
-            catch (HandledFatalException)
-            {
-                throw;
-            }
             catch (Exception e)
             {
-                FatalErrorHandler.HandleFatalError(new FatalException($"Fatal exception while generating field configuration for type {type}", e));
+                Exception e2 = new Exception($"Fatal exception while generating field configuration for type {type}", e);
+                FatalErrorHandler.HandleFatalError(e2);
+                throw e2;
             }
 
             dict[type] = list;

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -128,6 +128,15 @@ namespace B9PartSwitch
                 throw ex;
             }
 
+            string[] duplicatedNames = subtypes.GroupBy(s => s.Name).Where(g => g.Count() > 1).Select(g => g.Key).ToArray();
+
+            if (duplicatedNames.Length > 0)
+            {
+                Exception ex = new Exception($"Duplicated subtype names found on {this}: {string.Join(", ", duplicatedNames)}");
+                FatalErrorHandler.HandleFatalError(ex);
+                throw ex;
+            }
+
             InitializeSubtypes();
         }
 

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -133,6 +133,12 @@ namespace B9PartSwitch
                 FatalErrorHandler.HandleFatalError(ex);
                 throw ex;
             }
+            if (subtypes.Count == 1)
+            {
+                Exception ex = new Exception($"Must have at least two subtypes: {this}");
+                FatalErrorHandler.HandleFatalError(ex);
+                throw ex;
+            }
 
             string[] duplicatedNames = subtypes.GroupBy(s => s.Name).Where(g => g.Count() > 1).Select(g => g.Key).ToArray();
 

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -42,7 +42,7 @@ namespace B9PartSwitch
         [NodeData(name = "currentSubtype", persistent = true)]
         public string CurrentSubtypeName
         {
-            get => CurrentSubtype?.Name;
+            get => subtypes.Count > 0 ? CurrentSubtype?.Name : null;
             private set
             {
                 int index = subtypes.FindIndex(subtype => subtype.Name == value);

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -121,6 +121,13 @@ namespace B9PartSwitch
         {
             base.OnLoadPrefab(node);
 
+            if (subtypes.Count == 0)
+            {
+                Exception ex = new Exception($"No subtypes found on {this}");
+                FatalErrorHandler.HandleFatalError(ex);
+                throw ex;
+            }
+
             InitializeSubtypes();
         }
 

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -134,12 +134,31 @@ namespace B9PartSwitch
 
         public void Load(ConfigNode node, OperationContext context)
         {
-            OperationContext newContext = this.LoadFields(node, context);
+            OperationContext newContext;
+
+            try
+            {
+                newContext = this.LoadFields(node, context);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Exception while loading fields on subtype {this}", ex);
+            }
 
             OnLoad(node, newContext);
         }
 
-        public void Save(ConfigNode node, OperationContext context) => this.SaveFields(node, context);
+        public void Save(ConfigNode node, OperationContext context)
+        {
+            try
+            {
+                this.SaveFields(node, context);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Exception while loading fields on subtype {this}", ex);
+            }
+        }
 
         #endregion
 

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -166,6 +166,8 @@ namespace B9PartSwitch
 
         private void OnLoad(ConfigNode node, OperationContext context)
         {
+            if (Name.IsNullOrEmpty()) throw new Exception("Subtype has no name");
+
             if (tankType == null)
                 tankType = B9TankSettings.StructuralTankType;
 

--- a/B9PartSwitch/TankSettings/B9TankSettings.cs
+++ b/B9PartSwitch/TankSettings/B9TankSettings.cs
@@ -41,7 +41,18 @@ namespace B9PartSwitch
             {
                 TankType t = new TankType();
                 OperationContext context = new OperationContext(Operation.LoadPrefab, t);
-                t.Load(node, context);
+
+                try
+                {
+                    t.Load(node, context);
+                }
+                catch (Exception ex)
+                {
+                    Exception ex2 = new Exception($"Fatal exception while loading tank type {t.tankName ?? "<unknown>"}", ex);
+                    FatalErrorHandler.HandleFatalError(ex2);
+                    throw ex2;
+                }
+
                 if (tankTypes.ContainsKey(t.tankName))
                 {
                     Debug.LogError($"B9TankSettings: The tank type {t.tankName} already exists");

--- a/B9PartSwitchTests/Fishbones/FieldWrappers/FieldWrapperTest.cs
+++ b/B9PartSwitchTests/Fishbones/FieldWrappers/FieldWrapperTest.cs
@@ -54,6 +54,12 @@ namespace B9PartSwitchTests.Fishbones.FieldWrappers
         }
 
         [Fact]
+        public void TestName()
+        {
+            Assert.Equal("b", wrapper.Name);
+        }
+
+        [Fact]
         public void TestFieldType()
         {
             FieldWrapper wrapper1 = new FieldWrapper(typeof(DummyClass).GetField(nameof(DummyClass.b)));

--- a/B9PartSwitchTests/Fishbones/FieldWrappers/PropertyWrapperTest.cs
+++ b/B9PartSwitchTests/Fishbones/FieldWrappers/PropertyWrapperTest.cs
@@ -90,6 +90,12 @@ namespace B9PartSwitchTests.Fishbones.FieldWrappers
         }
 
         [Fact]
+        public void TestName()
+        {
+            Assert.Equal("b1", wrapper.Name);
+        }
+
+        [Fact]
         public void TestFieldType()
         {
             PropertyWrapper wrapper1 = new PropertyWrapper(typeof(DummyClass).GetProperty(nameof(DummyClass.b1)));

--- a/B9PartSwitchTests/Fishbones/NodeDataFieldTest.cs
+++ b/B9PartSwitchTests/Fishbones/NodeDataFieldTest.cs
@@ -28,6 +28,9 @@ namespace B9PartSwitchTests.Fishbones
         {
             Assert.Same(fieldWrapper, field.field);
             Assert.Same(operationManager, field.operationManager);
+
+            fieldWrapper.Name.Returns("abcde");
+            Assert.Equal("abcde", field.Name);
         }
 
         [Fact]

--- a/B9PartSwitchTests/Fishbones/NodeDataListTest.cs
+++ b/B9PartSwitchTests/Fishbones/NodeDataListTest.cs
@@ -62,6 +62,31 @@ namespace B9PartSwitchTests.Fishbones
             Assert.Throws<ArgumentNullException>(() => list.Load(node, null));
         }
 
+        [Fact]
+        public void TestLoad__Exception()
+        {
+            ConfigNode node = new ConfigNode();
+
+            object subject = new object();
+            OperationContext context = new OperationContext(Operation.LoadInstance, subject);
+
+            Exception ex = new Exception("some error");
+            field1.When(f => f.Load(node, context)).Throw(ex);
+            field1.Name.Returns("someField");
+
+            Exception ex2 = Assert.Throws<Exception>(delegate
+            {
+                list.Load(node, context);
+            });
+
+            Assert.Equal("Exception while loading field someField on type System.Object", ex2.Message);
+            
+            field2.DidNotReceiveWithAnyArgs().Load(null, null);
+
+            field1.DidNotReceiveWithAnyArgs().Save(null, null);
+            field2.DidNotReceiveWithAnyArgs().Save(null, null);
+        }
+
         #endregion
 
         #region Save
@@ -91,6 +116,31 @@ namespace B9PartSwitchTests.Fishbones
             
             Assert.Throws<ArgumentNullException>(() => list.Save(null, context));
             Assert.Throws<ArgumentNullException>(() => list.Save(node, null));
+        }
+
+        [Fact]
+        public void TestSave__Exception()
+        {
+            ConfigNode node = new ConfigNode();
+
+            object subject = new object();
+            OperationContext context = new OperationContext(Operation.Save, subject);
+
+            Exception ex = new Exception("some error");
+            field1.When(f => f.Save(node, context)).Throw(ex);
+            field1.Name.Returns("someField");
+
+            Exception ex2 = Assert.Throws<Exception>(delegate
+            {
+                list.Save(node, context);
+            });
+
+            Assert.Equal("Exception while saving field someField on type System.Object", ex2.Message);
+            
+            field2.DidNotReceiveWithAnyArgs().Save(null, null);
+
+            field1.DidNotReceiveWithAnyArgs().Load(null, null);
+            field2.DidNotReceiveWithAnyArgs().Load(null, null);
         }
 
         #endregion

--- a/B9PartSwitchTests/Fishbones/NodeDataListTest.cs
+++ b/B9PartSwitchTests/Fishbones/NodeDataListTest.cs
@@ -45,8 +45,8 @@ namespace B9PartSwitchTests.Fishbones
 
             list.Load(node, context);
 
-            field1.Received().Load(node, Arg.Is<OperationContext>(x => x.Operation == Operation.LoadInstance && x.Subject == subject));
-            field2.Received().Load(node, Arg.Is<OperationContext>(x => x.Operation == Operation.LoadInstance && x.Subject == subject));
+            field1.Received().Load(node, context);
+            field2.Received().Load(node, context);
 
             field1.DidNotReceiveWithAnyArgs().Save(null, null);
             field2.DidNotReceiveWithAnyArgs().Save(null, null);
@@ -76,8 +76,8 @@ namespace B9PartSwitchTests.Fishbones
 
             list.Save(node, context);
 
-            field1.Received().Save(node, Arg.Is<OperationContext>(x => x.Operation == Operation.Save && x.Subject == subject));
-            field2.Received().Save(node, Arg.Is<OperationContext>(x => x.Operation == Operation.Save && x.Subject == subject));
+            field1.Received().Save(node, context);
+            field2.Received().Save(node, context);
 
             field1.DidNotReceiveWithAnyArgs().Load(null, null);
             field2.DidNotReceiveWithAnyArgs().Load(null, null);


### PR DESCRIPTION
Resolves #95 

And then some...

Fatal errors should provide a lot more context now, both in the dialog and in the log.  Additional fatal errors when:
* Switcher has less than two subtypes
* Subtype names are duplicated
* Subtype has no name
* Modules conflict (not until you try to add the part to the editor)