### PR TITLE
Fix version file syntax error (extra close brace)

### DIFF
--- a/templates/B9PartSwitch.version.erb
+++ b/templates/B9PartSwitch.version.erb
@@ -8,5 +8,4 @@
   },
   "VERSION" : "<%= mod_version.to_s %>",
   "KSP_VERSION" : "<%= ksp_version.to_s(3) %>"
-  }
 }


### PR DESCRIPTION
One of the lines from the old implementation of KSP_VERSION got left behind.