### PR TITLE
Downgrade some errors to serious warnings

### DIFF
--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Extensions\TypeExtensions.cs" />
     <Compile Include="FARChecker.cs" />
     <Compile Include="Extensions\ListExtensions.cs" />
+    <Compile Include="SeriousWarningHandler.cs" />
     <Compile Include="TankSettings\B9TankSettings.cs" />
     <Compile Include="PartSwitch\ModuleB9PartSwitch.cs" />
     <Compile Include="PartSwitch\PartSubtype.cs" />

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -142,9 +142,9 @@ namespace B9PartSwitch
 
             if (duplicatedNames.Length > 0)
             {
-                Exception ex = new Exception($"Duplicated subtype names found on {this}: {string.Join(", ", duplicatedNames)}");
-                FatalErrorHandler.HandleFatalError(ex);
-                throw ex;
+                string duplicatedNamesList = string.Join(", ", duplicatedNames);
+                SeriousWarningHandler.DisplaySeriousWarning($"Duplicated subtype names found on {this}: {duplicatedNamesList}");
+                LogError($"Duplicate subtype names detected: {duplicatedNames}");
             }
 
             InitializeSubtypes();

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -166,7 +166,11 @@ namespace B9PartSwitch
 
         private void OnLoad(ConfigNode node, OperationContext context)
         {
-            if (Name.IsNullOrEmpty()) throw new Exception("Subtype has no name");
+            if (Name.IsNullOrEmpty())
+            {
+                SeriousWarningHandler.DisplaySeriousWarning($"Subtype has no name: {this}");
+                LogError("Subtype has no name");
+            }
 
             if (tankType == null)
                 tankType = B9TankSettings.StructuralTankType;

--- a/B9PartSwitch/SeriousWarningHandler.cs
+++ b/B9PartSwitch/SeriousWarningHandler.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace B9PartSwitch
+{
+    class SeriousWarningHandler
+    {
+        private const int MAX_MESSAGE_COUNT = 10;
+        private static PopupDialog dialog;
+        private static List<string> allMessages = new List<string>();
+
+        public static void DisplaySeriousWarning(string message)
+        {
+            try
+            {
+                UpsertDialog(message);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("Exception while trying to create the serious warning dialog");
+                Debug.LogException(ex);
+                Application.Quit();
+            }
+        }
+
+        private static void UpsertDialog(string message)
+        {
+            if (string.IsNullOrEmpty(message) || allMessages.Contains(message)) return;
+
+            if (allMessages.Count < MAX_MESSAGE_COUNT)
+            {
+                allMessages.Add(message);
+            }
+            else if (allMessages.Count == MAX_MESSAGE_COUNT)
+            {
+                Debug.LogError("[SeriousWarningHandler] Not displaying serious warning because too many warnings have already been added:");
+                Debug.LogError(message);
+                allMessages.Add("(too many warnings messages to display)");
+            }
+            else
+            {
+                Debug.LogError("[SeriousWarningHandler] Not displaying serious warning because too many warnings have already been added:");
+                Debug.LogError(message);
+                return;
+            }
+
+            if (dialog != null) dialog.Dismiss();
+
+            dialog = PopupDialog.SpawnPopupDialog(new Vector2(0.5f, 0.5f),
+                new Vector2(0.5f, 0.5f),
+                new MultiOptionDialog(
+                    "B9PartSwitchSeriousWarning",
+                    $"B9PartSwitch has encountered a serious warning. The game will continue to run but this should be fixed ASAP.\n\n{string.Join("\n\n", allMessages.ToArray())}\n\nPlease see KSP's log for addtional details",
+                    "B9PartSwitch - Serious Warning",
+                    HighLogic.UISkin,
+                    new Rect(0.5f, 0.5f, 500f, 60f),
+                    new DialogGUIFlexibleSpace(),
+                    new DialogGUIHorizontalLayout(
+                        new DialogGUIFlexibleSpace(),
+                        new DialogGUIButton("OK", delegate () { }, 140.0f, 30.0f, true),
+                        new DialogGUIFlexibleSpace()
+                    )
+                ),
+                true,
+                HighLogic.UISkin);
+        }
+    }
+}


### PR DESCRIPTION
User still gets an on-screen message but it can be dismissed without quitting the game

* Subtypes with no name
* Duplicate subtype names

These may become errors again at some point in the future but for now it's probably better to give some time for them to be fixed