### PR TITLE
Use .NET 4 in test assembly

### DIFF
--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -137,7 +137,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/B9PartSwitch/Fishbones/Parsers/Exceptions.cs
+++ b/B9PartSwitch/Fishbones/Parsers/Exceptions.cs
@@ -2,6 +2,7 @@
 
 namespace B9PartSwitch.Fishbones.Parsers
 {
+    [Serializable]
     public class ParseTypeNotRegisteredException : Exception
     {
         public ParseTypeNotRegisteredException(Type parseType) :
@@ -11,6 +12,7 @@ namespace B9PartSwitch.Fishbones.Parsers
         }
     }
 
+    [Serializable]
     public class ParseTypeAlreadyRegisteredException : Exception
     {
         public ParseTypeAlreadyRegisteredException(Type parseType) :

--- a/B9PartSwitch/Fishbones/Parsers/PartResourceDefinitionValueParser.cs
+++ b/B9PartSwitch/Fishbones/Parsers/PartResourceDefinitionValueParser.cs
@@ -5,6 +5,7 @@ namespace B9PartSwitch.Fishbones.Parsers
     // No test for this because PartResourceLibrary can't exist outside of Unity, and not worth writing a wrapper for so little
     public class PartResourceDefinitionValueParser : ValueParser<PartResourceDefinition>
     {
+        [Serializable]
         public class PartResourceNotFoundException : Exception
         {
             public PartResourceNotFoundException(string name) : base($"No resource definition named '{name}' could be found") { }

--- a/B9PartSwitch/Fishbones/Parsers/ValueParseMap.cs
+++ b/B9PartSwitch/Fishbones/Parsers/ValueParseMap.cs
@@ -11,8 +11,7 @@ namespace B9PartSwitch.Fishbones.Parsers
         {
             parseType.ThrowIfNullArgument(nameof(parseType));
 
-            IValueParser parser;
-            if (parsers.TryGetValue(parseType, out parser))
+            if (parsers.TryGetValue(parseType, out IValueParser parser))
                 return parser;
             else
                 throw new ParseTypeNotRegisteredException(parseType);

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using UniLinq;
 using UnityEngine;
-using KSP.Localization;
 using B9PartSwitch.Fishbones;
 
 namespace B9PartSwitch

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using UniLinq;
 using UnityEngine;
 using KSP.Localization;
@@ -73,8 +74,9 @@ namespace B9PartSwitch
 
         #region Private Fields
 
-        // Tweakscale integration
-        private float scale = 1f;
+        // Tweakscale integration (set via reflection, readonly is ok)
+        [SuppressMessage("Style", "IDE0044:Add readonly modifier")]
+        private readonly float scale = 1f;
 
         private ModuleB9PartSwitch parent;
         private List<ModuleB9PartSwitch> children = new List<ModuleB9PartSwitch>(0);

--- a/B9PartSwitch/packages.config
+++ b/B9PartSwitch/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net35" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="2.9.0" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/B9PartSwitchTests/B9PartSwitchTests.csproj
+++ b/B9PartSwitchTests/B9PartSwitchTests.csproj
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props')" />
-  <Import Project="..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
+  <Import Project="..\packages\xunit.runner.console.2.4.0\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.4.0\build\xunit.runner.console.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -42,18 +43,39 @@
       <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\packages\NSubstitute.2.0.3\lib\net35\NSubstitute.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.3.1.0\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.4.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.4.0\lib\net452\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.4.0\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -107,17 +129,24 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.console.2.4.0\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.4.0\build\xunit.runner.console.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
+  <Import Project="..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/B9PartSwitchTests/B9PartSwitchTests.csproj
+++ b/B9PartSwitchTests/B9PartSwitchTests.csproj
@@ -12,10 +12,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>B9PartSwitchTests</RootNamespace>
     <AssemblyName>B9PartSwitchTests</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -25,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +35,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/B9PartSwitchTests/B9PartSwitchTests.csproj
+++ b/B9PartSwitchTests/B9PartSwitchTests.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>B9PartSwitchTests</RootNamespace>
     <AssemblyName>B9PartSwitchTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/B9PartSwitchTests/Fishbones/FieldWrappers/FieldWrapperTest.cs
+++ b/B9PartSwitchTests/Fishbones/FieldWrappers/FieldWrapperTest.cs
@@ -44,7 +44,7 @@ namespace B9PartSwitchTests.Fishbones.FieldWrappers
 
             wrapper.SetValue(dummy, true);
 
-            Assert.Equal(true, dummy.b);
+            Assert.True(dummy.b);
         }
 
         [Fact]

--- a/B9PartSwitchTests/Fishbones/FieldWrappers/PropertyWrapperTest.cs
+++ b/B9PartSwitchTests/Fishbones/FieldWrappers/PropertyWrapperTest.cs
@@ -69,7 +69,7 @@ namespace B9PartSwitchTests.Fishbones.FieldWrappers
             DummyClass c = new DummyClass { b1 = false };
 
             wrapper.SetValue(c, true);
-            Assert.Equal(true, c.b1);
+            Assert.True(c.b1);
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace B9PartSwitchTests.Fishbones.FieldWrappers
             DummyClass c = new DummyClass();
 
             wrapper2.SetValue(c, true);
-            Assert.Equal(true, c.b3);
+            Assert.True(c.b3);
         }
 
         [Fact]

--- a/B9PartSwitchTests/Fishbones/FieldWrappers/PropertyWrapperTest.cs
+++ b/B9PartSwitchTests/Fishbones/FieldWrappers/PropertyWrapperTest.cs
@@ -9,16 +9,16 @@ namespace B9PartSwitchTests.Fishbones.FieldWrappers
     {
         private class DummyClass
         {
-            public bool b1 { get; set; }
-            public bool b2 { private get; set; }
-            public bool b3 { get; private set; } = false;
-            public bool b4 { get { return true; } }
-            public bool b5 { set { } }
+            public bool B1 { get; set; }
+            public bool B2 { private get; set; }
+            public bool B3 { get; private set; } = false;
+            public bool B4 => true;
+            public bool B5 { set { } }
 
-            public int i { get; set; }
+            public int I { get; set; }
         }
 
-        private static readonly PropertyWrapper wrapper = new PropertyWrapper(typeof(DummyClass).GetProperty(nameof(DummyClass.b1)));
+        private static readonly PropertyWrapper wrapper = new PropertyWrapper(typeof(DummyClass).GetProperty(nameof(DummyClass.B1)));
 
         [Fact]
         public void TestNew__Null()
@@ -29,30 +29,30 @@ namespace B9PartSwitchTests.Fishbones.FieldWrappers
         [Fact]
         public void TestNew__OnlyGetter()
         {
-            PropertyInfo property = typeof(DummyClass).GetProperty(nameof(DummyClass.b4));
+            PropertyInfo property = typeof(DummyClass).GetProperty(nameof(DummyClass.B4));
             Assert.Throws<ArgumentException>(() => new PropertyWrapper(property));
         }
 
         [Fact]
         public void TestNew__OnlySetter()
         {
-            PropertyInfo property = typeof(DummyClass).GetProperty(nameof(DummyClass.b5));
+            PropertyInfo property = typeof(DummyClass).GetProperty(nameof(DummyClass.B5));
             Assert.Throws<ArgumentException>(() => new PropertyWrapper(property));
         }
 
         [Fact]
         public void TestGetValue()
         {
-            DummyClass c = new DummyClass { b1 = true };
+            DummyClass c = new DummyClass { B1 = true };
             Assert.Equal(true, wrapper.GetValue(c));
         }
 
         [Fact]
         public void TestGetValue__Private()
         {
-            PropertyInfo property = typeof(DummyClass).GetProperty(nameof(DummyClass.b2));
+            PropertyInfo property = typeof(DummyClass).GetProperty(nameof(DummyClass.B2));
             PropertyWrapper wrapper2 = new PropertyWrapper(property);
-            DummyClass c = new DummyClass { b2 = true };
+            DummyClass c = new DummyClass { B2 = true };
 
             Assert.Equal(true, wrapper2.GetValue(c));
         }
@@ -66,21 +66,21 @@ namespace B9PartSwitchTests.Fishbones.FieldWrappers
         [Fact]
         public void TestSetValue()
         {
-            DummyClass c = new DummyClass { b1 = false };
+            DummyClass c = new DummyClass { B1 = false };
 
             wrapper.SetValue(c, true);
-            Assert.True(c.b1);
+            Assert.True(c.B1);
         }
 
         [Fact]
         public void TestSetValue__Private()
         {
-            PropertyInfo property = typeof(DummyClass).GetProperty(nameof(DummyClass.b3));
+            PropertyInfo property = typeof(DummyClass).GetProperty(nameof(DummyClass.B3));
             PropertyWrapper wrapper2 = new PropertyWrapper(property);
             DummyClass c = new DummyClass();
 
             wrapper2.SetValue(c, true);
-            Assert.True(c.b3);
+            Assert.True(c.B3);
         }
 
         [Fact]
@@ -92,14 +92,14 @@ namespace B9PartSwitchTests.Fishbones.FieldWrappers
         [Fact]
         public void TestName()
         {
-            Assert.Equal("b1", wrapper.Name);
+            Assert.Equal("B1", wrapper.Name);
         }
 
         [Fact]
         public void TestFieldType()
         {
-            PropertyWrapper wrapper1 = new PropertyWrapper(typeof(DummyClass).GetProperty(nameof(DummyClass.b1)));
-            PropertyWrapper wrapper2 = new PropertyWrapper(typeof(DummyClass).GetProperty(nameof(DummyClass.i)));
+            PropertyWrapper wrapper1 = new PropertyWrapper(typeof(DummyClass).GetProperty(nameof(DummyClass.B1)));
+            PropertyWrapper wrapper2 = new PropertyWrapper(typeof(DummyClass).GetProperty(nameof(DummyClass.I)));
 
             Assert.Same(typeof(bool), wrapper1.FieldType);
             Assert.Same(typeof(int), wrapper2.FieldType);
@@ -108,7 +108,7 @@ namespace B9PartSwitchTests.Fishbones.FieldWrappers
         [Fact]
         public void TestMemberInfo()
         {
-            MemberInfo info = typeof(DummyClass).GetProperty(nameof(DummyClass.b1));
+            MemberInfo info = typeof(DummyClass).GetProperty(nameof(DummyClass.B1));
 
             Assert.Same(info, wrapper.MemberInfo);
         }

--- a/B9PartSwitchTests/Fishbones/NodeDataMappers/NodeListMapperTest.cs
+++ b/B9PartSwitchTests/Fishbones/NodeDataMappers/NodeListMapperTest.cs
@@ -238,7 +238,7 @@ namespace B9PartSwitchTests.Fishbones.NodeDataMappers
 
             Assert.False(mapper.Load(ref value, node, Exemplars.LoadContext));
             Assert.Same(list, value);
-            Assert.Equal(1, list.Count);
+            Assert.Single(list);
 
             AssertDummyIConfigNode(list[0], "thing0");
         }
@@ -351,7 +351,7 @@ namespace B9PartSwitchTests.Fishbones.NodeDataMappers
 
             Assert.False(mapper.Save(list, node, Exemplars.SaveContext));
             Assert.False(node.HasNode("SOME_NODE"));
-            Assert.Equal(0, list.Count);
+            Assert.Empty(list);
         }
 
         [Fact]

--- a/B9PartSwitchTests/Fishbones/NodeDataMappers/NodeScalarMapperTest.cs
+++ b/B9PartSwitchTests/Fishbones/NodeDataMappers/NodeScalarMapperTest.cs
@@ -14,7 +14,6 @@ namespace B9PartSwitchTests.Fishbones.NodeDataMappers
         #region Constructor
 
         [Fact]
-
         public void TestNew()
         {
             NodeScalarMapper mapper2 = new NodeScalarMapper("blah", typeof(DummyIConfigNode));
@@ -23,6 +22,7 @@ namespace B9PartSwitchTests.Fishbones.NodeDataMappers
             Assert.Same(typeof(DummyIConfigNode), mapper2.fieldType);
         }
 
+        [Fact]
         public void TestNew__IContextualNode()
         {
             NodeScalarMapper mapper2 = new NodeScalarMapper("blah", typeof(DummyIContextualNode));
@@ -31,6 +31,7 @@ namespace B9PartSwitchTests.Fishbones.NodeDataMappers
             Assert.Same(typeof(DummyIContextualNode), mapper2.fieldType);
         }
 
+        [Fact]
         public void TestNew__BadType()
         {
             Assert.Throws<ArgumentException>(() => new NodeScalarMapper("blah", typeof(DummyClass)));

--- a/B9PartSwitchTests/Fishbones/NodeDataMappers/ValueListMapperTest.cs
+++ b/B9PartSwitchTests/Fishbones/NodeDataMappers/ValueListMapperTest.cs
@@ -137,7 +137,7 @@ namespace B9PartSwitchTests.Fishbones.NodeDataMappers
 
             Assert.False(mapper.Load(ref value, node, Exemplars.LoadContext));
             Assert.Same(list, value);
-            Assert.Equal(1, list.Count);
+            Assert.Single(list);
 
             Assert.Equal("blah0", list[0]);
         }

--- a/B9PartSwitchTests/Fishbones/Parsers/DefaultValueParseMapTest.cs
+++ b/B9PartSwitchTests/Fishbones/Parsers/DefaultValueParseMapTest.cs
@@ -67,7 +67,7 @@ namespace B9PartSwitchTests.Fishbones.Parsers
             IValueParseMap instance = DefaultValueParseMap.Instance;
 
             Assert.NotNull(instance);
-            Assert.IsNotType<IMutableValueParseMap>(instance);
+            Assert.Null(instance as IMutableValueParseMap);
         }
 
         #endregion
@@ -170,6 +170,7 @@ namespace B9PartSwitchTests.Fishbones.Parsers
 
         #region CanParse
 
+        [Fact]
         public void TestCanParse()
         {
             DefaultValueParseMap map = new DefaultValueParseMap();
@@ -181,6 +182,7 @@ namespace B9PartSwitchTests.Fishbones.Parsers
             Assert.True(map.CanParse(typeof(DummyClass)));
         }
 
+        [Fact]
         public void TestCanParse__Enum()
         {
             DefaultValueParseMap map = new DefaultValueParseMap();
@@ -188,6 +190,7 @@ namespace B9PartSwitchTests.Fishbones.Parsers
             Assert.True(map.CanParse(typeof(DummyEnum?)));
         }
 
+        [Fact]
         public void TestCanParse__Nullable()
         {
             DefaultValueParseMap map = new DefaultValueParseMap();
@@ -201,6 +204,7 @@ namespace B9PartSwitchTests.Fishbones.Parsers
             Assert.True(map.CanParse(typeof(DummyStruct?)));
         }
 
+        [Fact]
         public void TestCanParse__RegisteredEnum()
         {
             DefaultValueParseMap map = new DefaultValueParseMap();
@@ -216,6 +220,7 @@ namespace B9PartSwitchTests.Fishbones.Parsers
             Assert.True(map.CanParse(typeof(DummyEnum?)));
         }
 
+        [Fact]
         public void TestCanParse__RegisteredNullable()
         {
             DefaultValueParseMap map = new DefaultValueParseMap();

--- a/B9PartSwitchTests/Fishbones/Parsers/EnumValueParserTest.cs
+++ b/B9PartSwitchTests/Fishbones/Parsers/EnumValueParserTest.cs
@@ -14,12 +14,6 @@ namespace B9PartSwitchTests.Fishbones.Parsers
         }
 
         [Fact]
-        public void TestNew()
-        {
-            Assert.DoesNotThrow(() => new EnumValueParser(typeof(BlahEnum)));
-        }
-
-        [Fact]
         public void TestNew__Null()
         {
             Assert.Throws<ArgumentNullException>(() => new EnumValueParser(null));

--- a/B9PartSwitchTests/Fishbones/Parsers/NodeObjectWrapperTest.cs
+++ b/B9PartSwitchTests/Fishbones/Parsers/NodeObjectWrapperTest.cs
@@ -12,6 +12,7 @@ namespace B9PartSwitchTests.Fishbones.Parsers
     {
         #region IsNodeType
 
+        [Fact]
         public void TestIsNodeType()
         {
             Assert.True(NodeObjectWrapper.IsNodeType(typeof(DummyIConfigNode)));

--- a/B9PartSwitchTests/Fishbones/Parsers/NodeObjectWrapperTest.cs
+++ b/B9PartSwitchTests/Fishbones/Parsers/NodeObjectWrapperTest.cs
@@ -98,8 +98,10 @@ namespace B9PartSwitchTests.Fishbones.Parsers
         {
             ConfigNode node = new ConfigNode();
 
-            DummyIConfigNode dummy = new DummyIConfigNode();
-            dummy.value = "test5678";
+            DummyIConfigNode dummy = new DummyIConfigNode
+            {
+                value = "test5678"
+            };
             OperationContext context = new OperationContext(Operation.Save, "some object");
 
             NodeObjectWrapper.Save(dummy, node, context);
@@ -112,8 +114,10 @@ namespace B9PartSwitchTests.Fishbones.Parsers
         {
             ConfigNode node = new ConfigNode();
 
-            DummyIContextualNode dummy = new DummyIContextualNode();
-            dummy.value = "test5678";
+            DummyIContextualNode dummy = new DummyIContextualNode
+            {
+                value = "test5678"
+            };
             OperationContext context = new OperationContext(Operation.Save, "some object");
 
             NodeObjectWrapper.Save(dummy, node, context);

--- a/B9PartSwitchTests/TestUtils/AssertUtilTest.cs
+++ b/B9PartSwitchTests/TestUtils/AssertUtilTest.cs
@@ -49,7 +49,7 @@ namespace B9PartSwitchTests.TestUtils
 
             ConfigNode node2 = node1.CreateCopy();
 
-            Assert.DoesNotThrow(() => AssertUtil.ConfigNodesEqual(node1, node2));
+            AssertUtil.ConfigNodesEqual(node1, node2);
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace B9PartSwitchTests.TestUtils
         {
             ConfigNode node = new ConfigNode();
 
-            Assert.DoesNotThrow(() => AssertUtil.ConfigNodesEqual(null, null));
+            AssertUtil.ConfigNodesEqual(null, null);
             Assert.Throws<Xunit.Sdk.SameException>(() => AssertUtil.ConfigNodesEqual(node, null));
             Assert.Throws<Xunit.Sdk.SameException>(() => AssertUtil.ConfigNodesEqual(null, node));
         }

--- a/B9PartSwitchTests/app.config
+++ b/B9PartSwitchTests/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.4.1" newVersion="4.0.4.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/B9PartSwitchTests/app.config
+++ b/B9PartSwitchTests/app.config
@@ -1,15 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.4.1" newVersion="4.0.4.1" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.4.1" newVersion="4.0.4.1"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/></startup></configuration>

--- a/B9PartSwitchTests/packages.config
+++ b/B9PartSwitchTests/packages.config
@@ -1,8 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net35" developmentDependency="true" />
-  <package id="NSubstitute" version="2.0.3" targetFramework="net35" />
-  <package id="xunit" version="1.9.2" targetFramework="net35" />
-  <package id="xunit.runner.console" version="2.3.1" targetFramework="net35" developmentDependency="true" />
-  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net35" developmentDependency="true" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net46" />
+  <package id="Microsoft.Net.Compilers" version="2.9.0" targetFramework="net46" developmentDependency="true" />
+  <package id="NSubstitute" version="3.1.0" targetFramework="net46" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net46" />
+  <package id="xunit" version="2.4.0" targetFramework="net46" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net46" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net46" />
+  <package id="xunit.assert" version="2.4.0" targetFramework="net46" />
+  <package id="xunit.core" version="2.4.0" targetFramework="net46" />
+  <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net46" />
+  <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net46" />
+  <package id="xunit.runner.console" version="2.4.0" targetFramework="net46" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/B9PartSwitchTests/packages.config
+++ b/B9PartSwitchTests/packages.config
@@ -3,15 +3,15 @@
   <package id="Castle.Core" version="4.3.1" targetFramework="net46" />
   <package id="Microsoft.Net.Compilers" version="2.9.0" targetFramework="net46" developmentDependency="true" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net46" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net46" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net46" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net46" requireReinstallation="true" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net46" requireReinstallation="true" />
   <package id="xunit" version="2.4.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net46" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net46" />
-  <package id="xunit.assert" version="2.4.0" targetFramework="net46" />
+  <package id="xunit.assert" version="2.4.0" targetFramework="net46" requireReinstallation="true" />
   <package id="xunit.core" version="2.4.0" targetFramework="net46" />
   <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net46" />
   <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net46" />
-  <package id="xunit.runner.console" version="2.4.0" targetFramework="net46" developmentDependency="true" />
+  <package id="xunit.runner.console" version="2.4.0" targetFramework="net46" developmentDependency="true" requireReinstallation="true" />
   <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/bin/test
+++ b/bin/test
@@ -2,7 +2,7 @@
 
 set -e
 
-runtest="mono ./packages/xunit.runner.console.*/tools/net46/xunit.console.exe"
+runtest="mono ./packages/xunit.runner.console.*/tools/net471/xunit.console.exe"
 
 echo "Running tests..."
 

--- a/bin/test
+++ b/bin/test
@@ -2,7 +2,7 @@
 
 set -e
 
-runtest="mono ./packages/xunit.runner.console.*/tools/*/xunit.console.exe"
+runtest="mono ./packages/xunit.runner.console.*/tools/net46/xunit.console.exe"
 
 echo "Running tests..."
 


### PR DESCRIPTION
It works with the main assembly being .NET 3.5, it may be the case that tests are being run against .NET 4 runtimes anyway.  I don't really anticipate this causing any false positives/negatives in tests