### PR TITLE
Allow moving attach nodes

### DIFF
--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -99,6 +99,8 @@
     <Compile Include="Fishbones\UseParser.cs" />
     <Compile Include="Localization.cs" />
     <Compile Include="ModuleB9DisableTransform.cs" />
+    <Compile Include="PartSwitch\AttachNodeMover.cs" />
+    <Compile Include="PartSwitch\AttachNodeModifierInfo.cs" />
     <Compile Include="PartSwitch\ModuleB9PartInfo.cs" />
     <Compile Include="PartSwitch\PartSubtypeContext.cs" />
     <Compile Include="PartSwitch\PartSwitchFlightDialog.cs" />

--- a/B9PartSwitch/PartSwitch/AttachNodeModifierInfo.cs
+++ b/B9PartSwitch/PartSwitch/AttachNodeModifierInfo.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq;
+using UnityEngine;
+using B9PartSwitch.Fishbones;
+using B9PartSwitch.Fishbones.Context;
+
+namespace B9PartSwitch
+{
+    public class AttachNodeModifierInfo : IContextualNode
+    {
+        [NodeData(name = "name")]
+        public string nodeID;
+
+        [NodeData]
+        public Vector3? position;
+
+        public void Load(ConfigNode node, OperationContext context)
+        {
+            this.LoadFields(node, context);
+        }
+
+        public void Save(ConfigNode node, OperationContext context)
+        {
+            this.SaveFields(node, context);
+        }
+
+        public AttachNodeMover CreateAttachNodeModifier(Part part)
+        {
+            if (position == null) return null;
+            AttachNode node = part.attachNodes.FirstOrDefault(n => (n.nodeType == AttachNode.NodeType.Stack || n.nodeType == AttachNode.NodeType.Dock) && n.id == nodeID);
+
+            if (node == null)
+            {
+                part.LogError($"Attach node with id '{nodeID}' not found for attach node modifier");
+                return null;
+            }
+
+            return new AttachNodeMover(node, position.Value);
+        }
+    }
+}

--- a/B9PartSwitch/PartSwitch/AttachNodeMover.cs
+++ b/B9PartSwitch/PartSwitch/AttachNodeMover.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using UnityEngine;
+
+namespace B9PartSwitch
+{
+    public class AttachNodeMover
+    {
+        public readonly AttachNode attachNode;
+
+        public readonly Vector3 position;
+
+        public AttachNodeMover(AttachNode attachNode, Vector3 position)
+        {
+            attachNode.ThrowIfNullArgument(nameof(attachNode));
+
+            this.attachNode = attachNode;
+            this.position = position;
+        }
+
+        public void ActivateOnStart()
+        {
+            attachNode.position = position;
+        }
+
+        public void ActivateOnSwitch()
+    {
+            Vector3 offset = position - attachNode.position;
+            attachNode.position = position;
+
+            if (!HighLogic.LoadedSceneIsEditor) return;
+            if (attachNode.owner.parent != null && attachNode.owner.parent == attachNode.attachedPart)
+            {
+                attachNode.owner.transform.localPosition -= offset;
+            }
+            else if (attachNode.attachedPart != null)
+            {
+                attachNode.attachedPart.transform.localPosition += offset;
+            }
+        }
+
+        public void DeactivateOnSwitch()
+        {
+            Vector3 offset = attachNode.originalPosition - attachNode.position;
+            attachNode.position = attachNode.originalPosition;
+                
+            if (!HighLogic.LoadedSceneIsEditor) return;
+            if (attachNode.owner.parent != null && attachNode.owner.parent == attachNode.attachedPart)
+            {
+                attachNode.owner.transform.localPosition -= offset;
+            }
+            else if (attachNode.attachedPart != null)
+            {
+                attachNode.attachedPart.transform.localPosition += offset;
+            }
+        }
+    }
+}

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -103,6 +103,7 @@ namespace B9PartSwitch
         public IEnumerable<AttachNode> ManagedNodes => subtypes.SelectMany(subtype => subtype.Nodes);
         public IEnumerable<string> ManagedResourceNames => subtypes.SelectMany(subtype => subtype.ResourceNames);
         public IEnumerable<Material> ManagedMaterials => subtypes.SelectMany(subtype => subtype.Materials);
+        public IEnumerable<AttachNode> AttachNodesWithManagedPosition => subtypes.SelectMany(subtype => subtype.AttachNodesWithManagedPosition);
 
         public bool ManagesTransforms => ManagedTransforms.Any();
         public bool ManagesNodes => ManagedNodes.Any();
@@ -281,6 +282,8 @@ namespace B9PartSwitch
         }
 
         public bool IsManagedMaterial(Material material) => ManagedMaterials.Contains(material);
+
+        public bool IsAttachNodePositionManaged(AttachNode attachNode) => AttachNodesWithManagedPosition.Contains(attachNode);
 
         public bool PartFieldManaged(ISubtypePartField field) => subtypes.Any(subtype => field.ShouldUseOnSubtype(subtype.Context));
 
@@ -501,6 +504,14 @@ namespace B9PartSwitch
                     if (otherModule.IsManagedMaterial(material))
                     {
                         error += $"\n  Two modules cannot manage the same material: {material.name}";
+                    }
+                }
+
+                foreach (AttachNode attachNode in AttachNodesWithManagedPosition)
+                {
+                    if (otherModule.IsAttachNodePositionManaged(attachNode))
+                    {
+                        error += $"\n  Two modules cannot manage the same attach node's postition: {attachNode.id}";
                     }
                 }
 

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -26,6 +26,9 @@ namespace B9PartSwitch
         [NodeData(name = "TEXTURE")]
         public List<TextureSwitchInfo> textureSwitches = new List<TextureSwitchInfo>();
 
+        [NodeData(name = "NODE")]
+        public List<AttachNodeModifierInfo> attachNodeModifierInfos = new List<AttachNodeModifierInfo>();
+
         [NodeData]
         public float addedMass = 0f;
 
@@ -92,6 +95,7 @@ namespace B9PartSwitch
         private List<Transform> transforms = new List<Transform>();
         private List<AttachNode> nodes = new List<AttachNode>();
         private List<TextureReplacement> textureReplacements = new List<TextureReplacement>();
+        private List<AttachNodeMover> attachNodeMovers = new List<AttachNodeMover>();
 
         #endregion
 
@@ -110,6 +114,7 @@ namespace B9PartSwitch
         public IEnumerable<string> ResourceNames => tankType.ResourceNames;
         public IEnumerable<string> NodeIDs => nodes.Select(n => n.id);
         public IEnumerable<Material> Materials => textureReplacements.Select(repl => repl.material);
+        public IEnumerable<AttachNode> AttachNodesWithManagedPosition => attachNodeMovers.Select(mover => mover.attachNode);
 
         public float TotalVolume
         {
@@ -201,6 +206,7 @@ namespace B9PartSwitch
             FindObjects();
             FindNodes();
             FindTextureReplacements();
+            FindAttachNodeMovers();
         }
 
         #endregion
@@ -224,6 +230,7 @@ namespace B9PartSwitch
             ActivateTextures();
             AddResources(false);
             UpdatePartParams();
+            attachNodeMovers.ForEach(nm => nm.ActivateOnStart());
         }
 
         public void DeactivateOnSwitch()
@@ -237,6 +244,7 @@ namespace B9PartSwitch
 
             DeactivateTextures();
             RemoveResources();
+            attachNodeMovers.ForEach(nm => nm.DeactivateOnSwitch());
         }
 
         public void ActivateOnSwitch()
@@ -246,6 +254,7 @@ namespace B9PartSwitch
             ActivateTextures();
             AddResources(true);
             UpdatePartParams();
+            attachNodeMovers.ForEach(nm => nm.ActivateOnSwitch());
         }
 
         public void DeactivateForIcon()
@@ -404,6 +413,23 @@ namespace B9PartSwitch
                 catch(Exception e)
                 {
                     LogError("Exception while initializing a texture replacment:");
+                    Debug.LogException(e);
+                }
+            }
+        }
+
+        private void FindAttachNodeMovers()
+        {
+            foreach (AttachNodeModifierInfo info in attachNodeModifierInfos)
+            {
+                try
+                {
+                    AttachNodeMover mover = info.CreateAttachNodeModifier(Part);
+                    if (mover != null) attachNodeMovers.Add(mover);
+                }
+                catch (Exception e)
+                {
+                    LogError("Exception while initializing a node mover:");
                     Debug.LogException(e);
                 }
             }


### PR DESCRIPTION
One switcher can manage each node's position.  Subtypes that don't specify
any will use the original position.  To manage an attach node's postion
within a subype you would include a node like this:

```
NODE
{
    name = top01 // attach node id
    position = 0, 1, 0 // x,y,z position
}
```