### PR TITLE
Fix texture switch when copying parts

### DIFF
--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Fishbones\UseParser.cs" />
     <Compile Include="Localization.cs" />
     <Compile Include="ModuleB9DisableTransform.cs" />
+    <Compile Include="ModuleB9PropagateCopyEvents.cs" />
     <Compile Include="PartSwitch\AttachNodeMover.cs" />
     <Compile Include="PartSwitch\AttachNodeModifierInfo.cs" />
     <Compile Include="PartSwitch\ModuleB9PartInfo.cs" />

--- a/B9PartSwitch/ModuleB9PropagateCopyEvents.cs
+++ b/B9PartSwitch/ModuleB9PropagateCopyEvents.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace B9PartSwitch
+{
+    // Hack for these methods not being fired for child parts when copying in the editor - remove if this gets fixed in KSP
+    public class ModuleB9PropagateCopyEvents : PartModule
+    {
+        public override void OnAwake()
+        {
+            base.OnAwake();
+            enabled = false;
+            isEnabled = false;
+        }
+
+        public override void OnWillBeCopied(bool asSymCounterpart)
+        {
+            base.OnWillBeCopied(asSymCounterpart);
+
+            foreach (Part child in part.children)
+            {
+                child.OnWillBeCopied(asSymCounterpart);
+            }
+        }
+
+        public override void OnWasCopied(PartModule copyPartModule, bool asSymCounterpart)
+        {
+            base.OnWasCopied(copyPartModule, asSymCounterpart);
+
+            if (copyPartModule.part.children.Count == part.children.Count)
+            {
+                for (int i = 0; i < part.children.Count; i++)
+                {
+                    part.children[i].OnWasCopied(copyPartModule.part.children[i], asSymCounterpart);
+                }
+            }
+            else
+            {
+                this.LogInfo("Cannot fire OnWasCopied for children as child counts differ");
+            }
+        }
+    }
+}

--- a/B9PartSwitch/PartSwitch/TextureSwitchInfo.cs
+++ b/B9PartSwitch/PartSwitch/TextureSwitchInfo.cs
@@ -57,7 +57,7 @@ namespace B9PartSwitch
             IEnumerable<Renderer> renderers;
             if (baseTransformNames.IsNullOrEmpty() && transformNames.IsNullOrEmpty())
             {
-                renderers = part.GetModelRoot().GetComponentsInChildren<Renderer>();
+                renderers = part.GetModelRoot().GetComponentsInChildren<Renderer>(true);
             }
             else
             {
@@ -98,7 +98,7 @@ namespace B9PartSwitch
                 {
                     foundTransform = true;
 
-                    Renderer[] transformRenderers = transform.GetComponentsInChildren<Renderer>();
+                    Renderer[] transformRenderers = transform.GetComponentsInChildren<Renderer>(true);
 
                     if (transformRenderers.Length == 0)
                     {

--- a/GameData/B9PartSwitch/CopyEventsPropagator.cfg
+++ b/GameData/B9PartSwitch/CopyEventsPropagator.cfg
@@ -1,0 +1,7 @@
+@PART:FOR[zzzzzz-B9PartSwitch]
+{
+    MODULE
+    {
+        name = ModuleB9PropagateCopyEvents
+    }
+}


### PR DESCRIPTION
* `OnWillBeCopied` and `OnWasCopied` weren't being fired for child parts of the one being cloned, this lead to them not getting their textures properly reset
* Inactive renderers were being excluded, causing texture switches to not be initialized on disabled transforms after copying a part.