### PR TITLE
Only warning for other resource switching modules

### DIFF
--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -559,9 +559,11 @@ namespace B9PartSwitch
 
                 if (incompatibleModulesOnPart.Length > 0)
                 {
-                    Exception ex = new Exception($"Conflict found between {this} and {string.Join(", ", incompatibleModulesOnPart)} - cannot both manage resources on the same part");
-                    FatalErrorHandler.HandleFatalError(ex);
-                    throw ex;
+                    foreach (PartSubtype subtype in subtypes)
+                    {
+                        subtype.AssignStructuralTankType();
+                    }
+                    SeriousWarningHandler.DisplaySeriousWarning($"{this} and {string.Join(", ", incompatibleModulesOnPart)} - cannot both manage resources on the same part, B9 resource switching will be disabled");
                 }
 
             }


### PR DESCRIPTION
The likelyhood of this breaking craft is not that high, and it's still annoying enough that it'll probably get fixed quickly.  Disabling B9's resource switching is valid in this case.