### PR TITLE
Download KSP DLLs from S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,19 @@ language: csharp
 mono:
   - 5.12.0
 solution: B9PartSwitch.sln
+before_install:
+  - sudo apt-get install python3-pip
 install:
   - rvm install $(cat .ruby-version)
   - bundle install
-  - build_script/install/install_ksp_dlls.sh
+  - pip3 install awscli --upgrade --user
+  - install-ksp-dlls
   - nuget restore ${TRAVIS_SOLUTION}
 script:
   - msbuild /p:Configuration=Release /p:ReferencePath="${KSP_DLL_PATH}" ${TRAVIS_SOLUTION}
   - bin/test
   - build_script/script/make_release.sh
-  - bin/fill-version 'templates/B9PartSwitch.version.erb' 'release/GameData/B9PartSwitch/B9PartSwitch.version'
+  - fill-version 'templates/B9PartSwitch.version.erb' 'release/GameData/B9PartSwitch/B9PartSwitch.version'
   - bundle exec rake spec
   - build_script/script/make_zip.sh
 after_success:
@@ -51,7 +54,8 @@ env:
     - PROJECT_NAME='B9PartSwitch'
     - PROJECT_DIR='B9PartSwitch'
     - KSP_VERSION="$(cat KSP_VERSION)"
-    - KSP_DLL_PATH="${TRAVIS_BUILD_DIR}/KSP_DLLs/${KSP_VERSION}"
+    - KSP_DLL_PATH="/opt/ksp/assembly/${KSP_VERSION}"
+    - PATH="${PATH}:${TRAVIS_BUILD_DIR}/bin"
 notifications:
   email: false
 git:

--- a/bin/install-ksp-dlls
+++ b/bin/install-ksp-dlls
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+set -e
+
+export AWS_ACCESS_KEY_ID="${DLL_S3_ACCESS_KEY_ID}"
+export AWS_SECRET_ACCESS_KEY="${DLL_S3_SECRET_ACCESS_KEY}"
+aws s3 cp "s3://blowfish-ksp-dlls/ksp-${KSP_VERSION}.zip" '/var/tmp/KSP_DLLs.zip'
+mkdir -p "/opt/ksp/assembly/${KSP_VERSION}"
+unzip -P ${DLL_PACKAGE_ZIP_PASSPHRASE} '/var/tmp/KSP_DLLs.zip' -d "/opt/ksp/assembly/${KSP_VERSION}"
+rm '/var/tmp/KSP_DLLs.zip'

--- a/build_script/install/install_ksp_dlls.sh
+++ b/build_script/install/install_ksp_dlls.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-wget --no-check-certificate --quiet "https://drive.google.com/uc?export=download&id=${GDRIVE_DLL_PACKAGE_ID}" -O KSP_DLLs.zip
-unzip -P ${DLL_PACKAGE_ZIP_PASSPHRASE} KSP_DLLs.zip


### PR DESCRIPTION
The Google Drive package was getting too big, it makes you go through a confirmation step to download it.  This is simpler.  Make some improvements to how things are organized.