### PR TITLE
Move transforms

### DIFF
--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -116,10 +116,13 @@
     <Compile Include="PartSwitch\PartModifiers\PartSkinMaxTempModifier.cs" />
     <Compile Include="PartSwitch\PartModifiers\PartStackSymmetryModifier.cs" />
     <Compile Include="PartSwitch\PartModifiers\ResourceModifier.cs" />
+    <Compile Include="PartSwitch\PartModifiers\TransformMover.cs" />
+    <Compile Include="PartSwitch\PartModifiers\TransformRotator.cs" />
     <Compile Include="PartSwitch\PartModifiers\TransformToggler.cs" />
     <Compile Include="PartSwitch\PartSwitchFlightDialog.cs" />
     <Compile Include="PartSwitch\PartModifiers\TextureReplacement.cs" />
     <Compile Include="PartSwitch\TextureSwitchInfo.cs" />
+    <Compile Include="PartSwitch\TransformModifierInfo.cs" />
     <Compile Include="Serialization\SerializedDataContainer.cs" />
     <Compile Include="Extensions\AttachNodeExtensions.cs" />
     <Compile Include="Extensions\ObjectExtensions.cs" />

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -151,15 +151,6 @@ namespace B9PartSwitch
             InitializeSubtypes();
         }
 
-        protected override void OnLoadInstance(ConfigNode node)
-        {
-            base.OnLoadInstance(node);
-
-            InitializeSubtypes();
-            FindBestSubtype(node);
-            UpdateOnLoad();
-        }
-
         public override void OnIconCreate()
         {
             base.OnIconCreate();
@@ -355,6 +346,15 @@ namespace B9PartSwitch
 
         private void InitializeSubtypes()
         {
+            if (subtypes.Count == 0) return;
+
+            foreach (PartSubtype subtype in InactiveSubtypes)
+            {
+                subtype.OnBeforeReinitializeInactiveSubtype();
+            }
+
+            CurrentSubtype.OnBeforeReinitializeActiveSubtype();
+
             foreach (PartSubtype subtype in subtypes)
             {
                 subtype.Setup(this);

--- a/B9PartSwitch/PartSwitch/PartModifiers/AttachNodeToggler.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/AttachNodeToggler.cs
@@ -22,7 +22,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         public override void OnWillBeCopiedInactiveSubtype() => Activate();
         public override void OnWasCopiedInactiveSubtype() => Deactivate();
         public override void OnWasCopiedActiveSubtype() => MaybeActivate();
-        public override void OnBeforeReinitialize() => Activate();
+        public override void OnBeforeReinitializeInactiveSubtype() => Activate();
 
         private void MaybeActivate() => node.owner.UpdateNodeEnabled(node);
         private void Activate() => node.Unhide();

--- a/B9PartSwitch/PartSwitch/PartModifiers/IPartModifier.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/IPartModifier.cs
@@ -24,6 +24,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         void OnWillBeCopiedInactiveSubtype();
         void OnWasCopiedActiveSubtype();
         void OnWasCopiedInactiveSubtype();
-        void OnBeforeReinitialize();
+        void OnBeforeReinitializeInactiveSubtype();
+        void OnBeforeReinitializeActiveSubtype();
     }
 }

--- a/B9PartSwitch/PartSwitch/PartModifiers/PartModifierBase.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/PartModifierBase.cs
@@ -24,6 +24,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         public virtual void OnWillBeCopiedInactiveSubtype() { }
         public virtual void OnWasCopiedActiveSubtype() { }
         public virtual void OnWasCopiedInactiveSubtype() { }
-        public virtual void OnBeforeReinitialize() { }
+        public virtual void OnBeforeReinitializeInactiveSubtype() { }
+        public virtual void OnBeforeReinitializeActiveSubtype() { }
     }
 }

--- a/B9PartSwitch/PartSwitch/PartModifiers/TextureReplacement.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TextureReplacement.cs
@@ -38,7 +38,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         public override void OnIconCreateActiveSubtype() => Activate();
         public override void OnWillBeCopiedActiveSubtype() => Deactivate();
         public override void OnWasCopiedActiveSubtype() => Activate();
-        public override void OnBeforeReinitialize() => Deactivate();
+        public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
 
         private void Activate() => material.SetTexture(shaderProperty, newTexture);
         private void Deactivate() => material.SetTexture(shaderProperty, oldTexture);

--- a/B9PartSwitch/PartSwitch/PartModifiers/TransformMover.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TransformMover.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using UnityEngine;
+
+namespace B9PartSwitch.PartSwitch.PartModifiers
+{
+    public class TransformMover : PartModifierBase
+    {
+        private readonly Transform transform;
+        private readonly Vector3 offset;
+        private bool isActive = false;
+
+        public TransformMover(Transform transform, Vector3 offset)
+        {
+            transform.ThrowIfNullArgument(nameof(transform));
+
+            this.transform = transform;
+            this.offset = offset;
+        }
+
+        public override string Description => $"transform '{transform.name}' position offset";
+
+        public override void ActivateOnStartEditor() => Activate();
+        public override void ActivateOnStartFlight() => Activate();
+        public override void ActivateOnSwitchEditor() => Activate();
+        public override void ActivateOnSwitchFlight() => Activate();
+        public override void DeactivateOnSwitchEditor() => Deactivate();
+        public override void DeactivateOnSwitchFlight() => Deactivate();
+        public override void OnIconCreateActiveSubtype() => Activate();
+        public override void OnWillBeCopiedActiveSubtype() => Deactivate();
+        public override void OnWasCopiedActiveSubtype() => Activate();
+        public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
+
+        private void Activate()
+        {
+            if (isActive) return;
+
+            transform.localPosition += offset;
+            isActive = true;
+        }
+
+        private void Deactivate()
+        {
+            if (!isActive) return;
+
+            transform.localPosition -= offset;
+            isActive = false;
+        }
+    }
+}

--- a/B9PartSwitch/PartSwitch/PartModifiers/TransformRotator.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TransformRotator.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using UnityEngine;
+
+namespace B9PartSwitch.PartSwitch.PartModifiers
+{
+    public class TransformRotator : PartModifierBase
+    {
+        private readonly Transform transform;
+        private readonly Quaternion rotationOffset;
+        private bool isActive = false;
+
+        public TransformRotator(Transform transform, Quaternion rotationOffset)
+        {
+            transform.ThrowIfNullArgument(nameof(transform));
+
+            this.transform = transform;
+            this.rotationOffset = rotationOffset;
+        }
+
+        public override string Description => $"transform '{transform.name}' rotation offset";
+        public override object PartAspectLock => transform.GetInstanceID() + "---rotation";
+
+        public override void ActivateOnStartEditor() => Activate();
+        public override void ActivateOnStartFlight() => Activate();
+        public override void ActivateOnSwitchEditor() => Activate();
+        public override void ActivateOnSwitchFlight() => Activate();
+        public override void DeactivateOnSwitchEditor() => Deactivate();
+        public override void DeactivateOnSwitchFlight() => Deactivate();
+        public override void OnIconCreateActiveSubtype() => Activate();
+        public override void OnWillBeCopiedActiveSubtype() => Deactivate();
+        public override void OnWasCopiedActiveSubtype() => Activate();
+        public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
+
+        private void Activate()
+        {
+            if (isActive) return;
+
+            transform.localRotation *= rotationOffset;
+            isActive = true;
+        }
+
+        private void Deactivate()
+        {
+            if (!isActive) return;
+
+            transform.localRotation *= Quaternion.Inverse(rotationOffset);
+            isActive = false;
+        }
+    }
+}

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -31,6 +31,9 @@ namespace B9PartSwitch
         [NodeData(name = "NODE")]
         public List<AttachNodeModifierInfo> attachNodeModifierInfos = new List<AttachNodeModifierInfo>();
 
+        [NodeData(name = "TRANSFORM")]
+        public List<TransformModifierInfo> transformModifierInfos = new List<TransformModifierInfo>();
+
         [NodeData]
         public float addedMass = 0f;
 
@@ -344,6 +347,14 @@ namespace B9PartSwitch
 
                 if (!foundTransform)
                     OnInitializationError($"No transforms named '{transformName}' found");
+            }
+
+            foreach (TransformModifierInfo transformModifierInfo in transformModifierInfos)
+            {
+                foreach (IPartModifier partModifier in transformModifierInfo.CreatePartModifiers(part, OnInitializationError))
+                {
+                    MaybeAddModifier(partModifier);
+                }
             }
         }
 

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -113,9 +113,9 @@ namespace B9PartSwitch
         public IEnumerable<string> ResourceNames => tankType.ResourceNames;
         public IEnumerable<string> NodeIDs => nodes.Select(n => n.id);
 
-        public float TotalVolume => volumeProvider.Volume;
-        public float TotalMass => volumeProvider.Volume * tankType.tankMass + addedMass * parent.VolumeScale;
-        public float TotalCost => volumeProvider.Volume * tankType.TotalUnitCost + addedCost * parent.VolumeScale;
+        public float TotalVolume => volumeProvider?.Volume ?? 0f;
+        public float TotalMass => TotalVolume * tankType.tankMass + addedMass * (parent?.VolumeScale ?? 1f);
+        public float TotalCost => TotalVolume * tankType.TotalUnitCost + addedCost * (parent?.VolumeScale ?? 1f);
 
         public bool ChangesMass => (addedMass != 0f) || tankType.ChangesMass;
         public bool ChangesCost => (addedCost != 0f) || tankType.ChangesCost;
@@ -183,6 +183,22 @@ namespace B9PartSwitch
             }
         }
 
+        public void OnBeforeReinitializeInactiveSubtype()
+        {
+            foreach(IPartModifier modifier in partModifiers)
+            {
+                modifier.OnBeforeReinitializeInactiveSubtype();
+            }
+        }
+
+        public void OnBeforeReinitializeActiveSubtype()
+        {
+            foreach (IPartModifier modifier in partModifiers)
+            {
+                modifier.OnBeforeReinitializeActiveSubtype();
+            }
+        }
+
         public void Setup(ModuleB9PartSwitch parent)
         {
             if (parent == null)
@@ -196,8 +212,6 @@ namespace B9PartSwitch
 
             Part part = parent.part;
             Part partPrefab = part.GetPrefab() ?? part;
-
-            partModifiers.ForEach(modifier => modifier.OnBeforeReinitialize());
             partModifiers.Clear();
 
             IEnumerable<object> aspectLocksOnOtherModules = parent.PartAspectLocksOnOtherModules;

--- a/B9PartSwitch/PartSwitch/TransformModifierInfo.cs
+++ b/B9PartSwitch/PartSwitch/TransformModifierInfo.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using B9PartSwitch.Fishbones;
+using B9PartSwitch.Fishbones.Context;
+using B9PartSwitch.PartSwitch.PartModifiers;
+
+namespace B9PartSwitch
+{
+    public class TransformModifierInfo : IContextualNode
+    {
+        [NodeData(name = "name")]
+        public string transformName;
+
+        [NodeData]
+        public Vector3? positionOffset;
+
+        [NodeData]
+        public Vector3? rotationOffset;
+
+        public void Load(ConfigNode node, OperationContext context) => this.LoadFields(node, context);
+        public void Save(ConfigNode node, OperationContext context) => this.SaveFields(node, context);
+
+        public IEnumerable<IPartModifier> CreatePartModifiers(Part part, Action<string> onError)
+        {
+            part.ThrowIfNullArgument(nameof(part));
+            onError.ThrowIfNullArgument(nameof(onError));
+
+            if (string.IsNullOrEmpty(transformName))
+            {
+                onError("transform name is empty");
+                yield break;
+            }
+
+            bool foundTransform = false;
+
+            foreach (Transform transform in part.GetModelTransforms(transformName))
+            {
+                foundTransform = true;
+
+                if (positionOffset.HasValue)
+                {
+                    yield return new TransformMover(transform, positionOffset.Value);
+                }
+                if (rotationOffset.HasValue)
+                {
+                    yield return new TransformRotator(transform, Quaternion.Euler(rotationOffset.Value));
+                }
+            }
+
+            if (!foundTransform) onError($"Could not find any transform named '{transformName}'");
+        }
+    }
+}


### PR DESCRIPTION
* Clean up reinitialize hook and split into active and inactive
* Subtypes handle volume, cost, mass without error pre-initialization
* Eliminate initialization in OnLoad for instance (wait until start)
* Allow moving and rotating transforms
  * Subtypes now allow `TRANSFORM` nodes, with `name =` transform name, `positionOffset`, `rotationOffset`