### PR TITLE
Switch in flight action groups

### DIFF
--- a/B9PartSwitch/Localization.cs
+++ b/B9PartSwitch/Localization.cs
@@ -5,10 +5,10 @@ namespace B9PartSwitch
 {
     public static class Localization
     {
-        public static string PartSwitchFlightDialog_ResourcesWillBeDumpedWarning { get; private set; }
+        private static string partSwitchFlightDialog_ResourcesWillBeDumpedWarning;
         public static string PartSwitchFlightDialog_ConfirmResourceRemovalDialogTitle { get; private set; }
-        public static string PartSwitchFlightDialog_SelectNewSubtypeDialogTitle { get; private set; }
-        public static string PartSwitchFlightDialog_CurrentSubtypeLabel { get; private set; }
+        private static string partSwitchFlightDialog_SelectNewSubtypeDialogTitle;
+        private static string partSwitchFlightDialog_CurrentSubtypeLabel;
         public static string PartSwitchFlightDialog_AcceptString { get; private set; }
         public static string PartSwitchFlightDialog_CancelString { get; private set; }
 
@@ -16,6 +16,21 @@ namespace B9PartSwitch
         public static string ModuleB9PartSwitch_TankVolumeString { get; private set; }
         public static string ModuleB9PartSwitch_DefaultSwitcherDescription { get; private set; }
         public static string ModuleB9PartSwitch_DefaultSwitcherDescriptionPlural { get; private set; }
+
+        public static string PartSwitchFlightDialog_ResourcesWillBeDumpedWarning(string partName, string switcherDescription)
+        {
+            return Localizer.Format(partSwitchFlightDialog_ResourcesWillBeDumpedWarning, partName, switcherDescription);
+        }
+
+        public static string PartSwitchFlightDialog_SelectNewSubtypeDialogTitle(string switcherDescription)
+        {
+            return Localizer.Format(partSwitchFlightDialog_SelectNewSubtypeDialogTitle, switcherDescription);
+        }
+
+        public static string PartSwitchFlightDialog_CurrentSubtypeLabel(string currentSubtypeName)
+        {
+            return Localizer.Format(partSwitchFlightDialog_CurrentSubtypeLabel, currentSubtypeName);
+        }
 
         static Localization()
         {
@@ -26,10 +41,10 @@ namespace B9PartSwitch
 
         private static void RefreshLocalization()
         {
-            PartSwitchFlightDialog_ResourcesWillBeDumpedWarning = Localizer.GetStringByTag("#LOC_B9PartSwitch_PartSwitchFlightDialog_resources_will_be_dumped_warning");
+            partSwitchFlightDialog_ResourcesWillBeDumpedWarning = Localizer.GetStringByTag("#LOC_B9PartSwitch_PartSwitchFlightDialog_resources_will_be_dumped_warning");
             PartSwitchFlightDialog_ConfirmResourceRemovalDialogTitle = Localizer.GetStringByTag("#LOC_B9PartSwitch_PartSwitchFlightDialog_confirm_resource_removal_dialog_title");
-            PartSwitchFlightDialog_SelectNewSubtypeDialogTitle = Localizer.GetStringByTag("#LOC_B9PartSwitch_PartSwitchFlightDialog_select_new_subtype_dialog_title");
-            PartSwitchFlightDialog_CurrentSubtypeLabel = Localizer.GetStringByTag("#LOC_B9PartSwitch_PartSwitchFlightDialog_current_subtype_label");
+            partSwitchFlightDialog_SelectNewSubtypeDialogTitle = Localizer.GetStringByTag("#LOC_B9PartSwitch_PartSwitchFlightDialog_select_new_subtype_dialog_title");
+            partSwitchFlightDialog_CurrentSubtypeLabel = Localizer.GetStringByTag("#LOC_B9PartSwitch_PartSwitchFlightDialog_current_subtype_label");
             PartSwitchFlightDialog_AcceptString = Localizer.GetStringByTag("#autoLOC_6001205"); // Accept
             PartSwitchFlightDialog_CancelString = Localizer.GetStringByTag("#autoLOC_6001206"); // Cancel
 

--- a/B9PartSwitch/Localization.cs
+++ b/B9PartSwitch/Localization.cs
@@ -34,7 +34,6 @@ namespace B9PartSwitch
 
         static Localization()
         {
-            GameEvents.onLanguageSwitched.debugEvent = true;
             GameEvents.onLanguageSwitched.Add(() => RefreshLocalization());
             RefreshLocalization();
         }

--- a/B9PartSwitch/Localization.cs
+++ b/B9PartSwitch/Localization.cs
@@ -16,6 +16,9 @@ namespace B9PartSwitch
         public static string ModuleB9PartSwitch_TankVolumeString { get; private set; }
         public static string ModuleB9PartSwitch_DefaultSwitcherDescription { get; private set; }
         public static string ModuleB9PartSwitch_DefaultSwitcherDescriptionPlural { get; private set; }
+        private static string moduleB9PartSwitch_SelectSubtype;
+        private static string moduleB9PartSwitch_NextSubtype;
+        private static string moduleB9PartSwitch_PreviousSubtype;
 
         public static string PartSwitchFlightDialog_ResourcesWillBeDumpedWarning(string partName, string switcherDescription)
         {
@@ -30,6 +33,21 @@ namespace B9PartSwitch
         public static string PartSwitchFlightDialog_CurrentSubtypeLabel(string currentSubtypeName)
         {
             return Localizer.Format(partSwitchFlightDialog_CurrentSubtypeLabel, currentSubtypeName);
+        }
+
+        public static string ModuleB9PartSwitch_SelectSubtype(string switcherDescription)
+        {
+            return Localizer.Format(moduleB9PartSwitch_SelectSubtype, switcherDescription);
+        }
+
+        public static string ModuleB9PartSwitch_NextSubtype(string switcherDescription)
+        {
+            return Localizer.Format(moduleB9PartSwitch_NextSubtype, switcherDescription);
+        }
+
+        public static string ModuleB9PartSwitch_PreviousSubtype(string switcherDescription)
+        {
+            return Localizer.Format(moduleB9PartSwitch_PreviousSubtype, switcherDescription);
         }
 
         static Localization()
@@ -51,6 +69,9 @@ namespace B9PartSwitch
             ModuleB9PartSwitch_TankVolumeString = Localizer.GetStringByTag("#LOC_B9PartSwitch_ModuleB9PartSwitch_tank_volume");
             ModuleB9PartSwitch_DefaultSwitcherDescription = Localizer.GetStringByTag("#LOC_B9PartSwitch_ModuleB9PartSwitch_default_switcher_description");
             ModuleB9PartSwitch_DefaultSwitcherDescriptionPlural = Localizer.GetStringByTag("#LOC_B9PartSwitch_ModuleB9PartSwitch_default_switcher_description_plural");
+            moduleB9PartSwitch_SelectSubtype = Localizer.GetStringByTag("#LOC_B9PartSwitch_ModuleB9PartSwitch_select_subtype");
+            moduleB9PartSwitch_NextSubtype = Localizer.GetStringByTag("#LOC_B9PartSwitch_ModuleB9PartSwitch_next_subtype");
+            moduleB9PartSwitch_PreviousSubtype = Localizer.GetStringByTag("#LOC_B9PartSwitch_ModuleB9PartSwitch_previous_subtype");
         }
     }
 }

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -487,7 +487,7 @@ namespace B9PartSwitch
             chooseOption.onFieldChanged = OnSliderUpdate;
 
             BaseEvent switchSubtypeEvent = Events[nameof(ShowSubtypesWindow)];
-            switchSubtypeEvent.guiName = $"Switch {switcherDescription}";
+            switchSubtypeEvent.guiName = Localization.ModuleB9PartSwitch_SelectSubtype(switcherDescription); // Select <<1>>
             switchSubtypeEvent.advancedTweakable = advancedTweakablesOnly;
             switchSubtypeEvent.guiActiveEditor = subtypes.Count > 1;
 

--- a/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
+++ b/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using KSP.Localization;
 
 namespace B9PartSwitch
 {
@@ -29,7 +28,7 @@ namespace B9PartSwitch
             PopupDialog.SpawnPopupDialog(
                 new MultiOptionDialog(
                     "B9PartSwitch_SwitchInFlightWarning",
-                    Localizer.Format(Localization.PartSwitchFlightDialog_ResourcesWillBeDumpedWarning, module.part.partInfo.title, module.switcherDescription), // <<1>> has resources that will be dumped by switching the <<2>>
+                    Localization.PartSwitchFlightDialog_ResourcesWillBeDumpedWarning(module.part.partInfo.title, module.switcherDescription), // <<1>> has resources that will be dumped by switching the <<2>>
                     Localization.PartSwitchFlightDialog_ConfirmResourceRemovalDialogTitle, // Confirm Resource Removal
                     HighLogic.UISkin,
                     new DialogGUIButton(Localization.PartSwitchFlightDialog_AcceptString, () => onConfirm()),
@@ -45,7 +44,7 @@ namespace B9PartSwitch
             PopupDialog.SpawnPopupDialog(
                 new MultiOptionDialog(
                     "B9PartSwitch_SwitchInFlight",
-                    Localizer.Format(Localization.PartSwitchFlightDialog_SelectNewSubtypeDialogTitle, module.switcherDescription), // Select <<1>>
+                    Localization.PartSwitchFlightDialog_SelectNewSubtypeDialogTitle(module.switcherDescription), // Select <<1>>
                     module.part.partInfo.title,
                     HighLogic.UISkin,
                     CreateOptions(module)
@@ -63,7 +62,7 @@ namespace B9PartSwitch
             {
                 if (subtype == module.CurrentSubtype)
                 {
-                    options.Add(new DialogGUILabel(Localizer.Format(Localization.PartSwitchFlightDialog_CurrentSubtypeLabel, subtype.title), HighLogic.UISkin.button)); // <<1>> (Current)
+                    options.Add(new DialogGUILabel(Localization.PartSwitchFlightDialog_CurrentSubtypeLabel(subtype.title), HighLogic.UISkin.button)); // <<1>> (Current)
                 }
                 else if (HighLogic.LoadedSceneIsEditor || subtype.allowSwitchInFlight)
                 {

--- a/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
+++ b/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
@@ -9,19 +9,22 @@ namespace B9PartSwitch
     {
         public static void Spawn(ModuleB9PartSwitch module)
         {
-            bool showWarning = HighLogic.LoadedSceneIsFlight && module.CurrentTankType.ResourceNames.Any(name => module.part.Resources[name].amount > 0);
+            MaybeCreateResourceRemovalWarning(module, () => CreateDialogue(module));
+        }
 
-            if (showWarning)
+        public static void MaybeCreateResourceRemovalWarning(ModuleB9PartSwitch module, Action onConfirm)
+        {
+            if (HighLogic.LoadedSceneIsFlight && module.CurrentTankType.ResourceNames.Any(name => module.part.Resources[name].amount > 0))
             {
-                CreateWarning(module);
+                CreateWarning(module, onConfirm);
             }
             else
             {
-                CreateDialogue(module);
+                onConfirm();
             }
         }
 
-        private static void CreateWarning(ModuleB9PartSwitch module)
+        private static void CreateWarning(ModuleB9PartSwitch module, Action onConfirm)
         {
             PopupDialog.SpawnPopupDialog(
                 new MultiOptionDialog(
@@ -29,8 +32,8 @@ namespace B9PartSwitch
                     Localizer.Format(Localization.PartSwitchFlightDialog_ResourcesWillBeDumpedWarning, module.part.partInfo.title, module.switcherDescription), // <<1>> has resources that will be dumped by switching the <<2>>
                     Localization.PartSwitchFlightDialog_ConfirmResourceRemovalDialogTitle, // Confirm Resource Removal
                     HighLogic.UISkin,
-                    new DialogGUIButton(Localization.PartSwitchFlightDialog_AcceptString, () => CreateDialogue(module)),
-                    new DialogGUIButton(Localization.PartSwitchFlightDialog_CancelString, delegate { } )
+                    new DialogGUIButton(Localization.PartSwitchFlightDialog_AcceptString, () => onConfirm()),
+                    new DialogGUIButton(Localization.PartSwitchFlightDialog_CancelString, delegate { })
                 ),
                 false,
                 HighLogic.UISkin

--- a/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
+++ b/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
@@ -8,6 +8,7 @@ namespace B9PartSwitch
     {
         public static void Spawn(ModuleB9PartSwitch module)
         {
+            if (!module.subtypes.Any(subtype => subtype != module.CurrentSubtype && subtype.allowSwitchInFlight)) return;
             MaybeCreateResourceRemovalWarning(module, () => CreateDialogue(module));
         }
 

--- a/GameData/B9PartSwitch/Localization/en-us.cfg
+++ b/GameData/B9PartSwitch/Localization/en-us.cfg
@@ -6,6 +6,9 @@ Localization
         #LOC_B9PartSwitch_ModuleB9PartSwitch_tank_volume = Volume
         #LOC_B9PartSwitch_ModuleB9PartSwitch_default_switcher_description = Subtype
         #LOC_B9PartSwitch_ModuleB9PartSwitch_default_switcher_description_plural = Subtypes
+        #LOC_B9PartSwitch_ModuleB9PartSwitch_select_subtype = Select <<1>>
+        #LOC_B9PartSwitch_ModuleB9PartSwitch_next_subtype = Next <<1>>
+        #LOC_B9PartSwitch_ModuleB9PartSwitch_previous_subtype = Previous <<1>>
         #LOC_B9PartSwitch_PartSwitchFlightDialog_resources_will_be_dumped_warning = <<1>> has resources that will be dumped by switching the <<2>>
         #LOC_B9PartSwitch_PartSwitchFlightDialog_confirm_resource_removal_dialog_title = Confirm Resource Removal
         #LOC_B9PartSwitch_PartSwitchFlightDialog_select_new_subtype_dialog_title = Select <<1>>


### PR DESCRIPTION
* Add the following fields:
  * `showPreviousSubtypeAction` (default false)
  * `showNextSubtypeAction` (default false)
* Add the following action groups
  * Switch Subtype
    * Shows window with list of subtypes
    * Vislible if switchInFlight is true and there is at least one subtype allowing switch in flight
  * Next Subtype
    * Goes to the next subtype
    * Shows warning if resources will be removed
    * Visible if `switchInFlight` is true, `showNextSubtypeAction` is true, and at least one subtype allows switching in flight
  * PreviousSubtype
    * Goes to the next subtype
    * Shows warning if resources will be removed
    * Visible if `switchInFlight` is true, `showPreviousSubtypeAction` is true, and at least one subtype allows switching in flight
* Adds the following localization keys (currently only `en-us`):
  * `#LOC_B9PartSwitch_ModuleB9PartSwitch_select_subtype`
  * `#LOC_B9PartSwitch_ModuleB9PartSwitch_next_subtype`
  * `#LOC_B9PartSwitch_ModuleB9PartSwitch_previous_subtype`
* Localize Switch Subtype button