### PR TITLE
Add mirrorSymmetrySubtype field

### DIFF
--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -382,6 +382,9 @@ namespace B9PartSwitch
             }
 
             CurrentSubtype.OnWasCopiedActiveSubtype();
+
+            if (asSymCounterpart && part.symMethod == SymmetryMethod.Mirror && CurrentSubtype.mirrorSymmetrySubtype != CurrentSubtypeName)
+                ((ModuleB9PartSwitch)copyPartModule).UpdateFromSymmetry(CurrentSubtype.mirrorSymmetrySubtype);
         }
 
         public bool HasPartAspectLock(object partAspectLock) => PartAspectLocks.Contains(partAspectLock);
@@ -586,8 +589,15 @@ namespace B9PartSwitch
 
             if (HighLogic.LoadedSceneIsEditor)
             {
+                string symmetrySubtypeName;
+
+                if (part.symMethod == SymmetryMethod.Mirror)
+                    symmetrySubtypeName = CurrentSubtype.mirrorSymmetrySubtype;
+                else
+                    symmetrySubtypeName = CurrentSubtypeName;
+
                 foreach (var counterpart in this.FindSymmetryCounterparts())
-                    counterpart.UpdateFromSymmetry(currentSubtypeIndex);
+                    counterpart.UpdateFromSymmetry(symmetrySubtypeName);
 
                 GameEvents.onEditorPartEvent.Fire(ConstructionEventType.PartTweaked, part);
                 GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
@@ -602,11 +612,11 @@ namespace B9PartSwitch
             UpdatePartActionWindow();
         }
 
-        private void UpdateFromSymmetry(int newIndex)
+        private void UpdateFromSymmetry(string newSubtypeName)
         {
             CurrentSubtype.DeactivateOnSwitch();
 
-            currentSubtypeIndex = newIndex;
+            CurrentSubtypeName = newSubtypeName;
 
             UpdateSubtype();
         }

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -92,6 +92,9 @@ namespace B9PartSwitch
         [NodeData]
         public bool allowSwitchInFlight = true;
 
+        [NodeData]
+        public string mirrorSymmetrySubtype;
+
         #endregion
 
         #region Private Fields
@@ -171,6 +174,9 @@ namespace B9PartSwitch
 
             if (tankType == null)
                 tankType = B9TankSettings.StructuralTankType;
+
+            if (mirrorSymmetrySubtype == null)
+                mirrorSymmetrySubtype = Name;
 
             if (context.Operation == Operation.LoadPrefab)
             {
@@ -355,6 +361,12 @@ namespace B9PartSwitch
                 {
                     MaybeAddModifier(partModifier);
                 }
+            }
+
+            if (!parent.subtypes.Any(subtype => subtype.Name == mirrorSymmetrySubtype))
+            {
+                OnInitializationError($"Cannot find subtype '{mirrorSymmetrySubtype}' for mirror symmetry subtype");
+                mirrorSymmetrySubtype = Name;
             }
         }
 


### PR DESCRIPTION
Defined on the subtype - if set, when placing parts in mirror symmetry in the editor, it will use this subtype for the symmetry counterparts