### PR TITLE
Improve UI

### DIFF
--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -148,6 +148,7 @@
     <Compile Include="UI\UI_SubtypeSelector.cs" />
     <Compile Include="Utils\ColorParser.cs" />
     <Compile Include="Utils\GroupedStringBuilder.cs" />
+    <Compile Include="Utils\ResourceColors.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -140,6 +140,7 @@
     <Compile Include="TankSettings\TankTypeValueParser.cs" />
     <Compile Include="Test\ModuleB9PartSwitchTest.cs" />
     <Compile Include="Test\PartModuleTest.cs" />
+    <Compile Include="Utils\ColorParser.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -140,7 +140,14 @@
     <Compile Include="TankSettings\TankTypeValueParser.cs" />
     <Compile Include="Test\ModuleB9PartSwitchTest.cs" />
     <Compile Include="Test\PartModuleTest.cs" />
+    <Compile Include="UI\PrefabManager.cs" />
+    <Compile Include="UI\SwitcherSubtypeDescriptionGenerator.cs" />
+    <Compile Include="UI\TooltipHelper.cs" />
+    <Compile Include="UI\UIPartActionSubtypeButton.cs" />
+    <Compile Include="UI\UIPartActionSubtypeSelector.cs" />
+    <Compile Include="UI\UI_SubtypeSelector.cs" />
     <Compile Include="Utils\ColorParser.cs" />
+    <Compile Include="Utils\GroupedStringBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/B9PartSwitch/Extensions/PartExtensions.cs
+++ b/B9PartSwitch/Extensions/PartExtensions.cs
@@ -67,6 +67,8 @@ namespace B9PartSwitch
             return resource;
         }
 
+        public static float GetResourceMassMax(this Part part) => part.Resources.Sum(resource => (float)resource.maxAmount * resource.info.density);
+
         public static float GetResourceCostMax(this Part part) => part.Resources.Sum(resource => (float)resource.maxAmount * resource.info.unitCost);
         public static float GetResourceCostOffset(this Part part) => part.Resources.Sum(resource => (float)(resource.amount - resource.maxAmount) * resource.info.unitCost);
 

--- a/B9PartSwitch/Fishbones/NodeDataObjectExtensions.cs
+++ b/B9PartSwitch/Fishbones/NodeDataObjectExtensions.cs
@@ -47,7 +47,25 @@ namespace B9PartSwitch.Fishbones
         {
             obj.ThrowIfNullArgument(nameof(obj));
 
-            return obj.SerializeToNode().ToString();
+            ConfigNode node = obj.SerializeToNode();
+
+            void EscapeValuesRecursive(ConfigNode theNode)
+            {
+                foreach (ConfigNode subNode in theNode.nodes)
+                {
+                    EscapeValuesRecursive(subNode);
+                }
+
+                foreach (ConfigNode.Value value in theNode.values)
+                {
+                    value.value = value.value.Replace("\n", "\\n");
+                    value.value = value.value.Replace("\t", "\\t");
+                }
+            }
+
+            EscapeValuesRecursive(node);
+
+            return node.ToString();
         }
 
         public static ConfigNode SerializeToNode(this object obj)
@@ -92,6 +110,22 @@ namespace B9PartSwitch.Fishbones
 
             ConfigNode dataNode = node.GetNode(SERIALIZED_NODE);
             if (dataNode.IsNull()) throw new FormatException("No serialized data node found");
+
+            void UnescapeValuesRecursive(ConfigNode theNode)
+            {
+                foreach (ConfigNode subNode in theNode.nodes)
+                {
+                    UnescapeValuesRecursive(subNode);
+                }
+
+                foreach (ConfigNode.Value value in theNode.values)
+                {
+                    value.value = value.value.Replace("\\n", "\n");
+                    value.value = value.value.Replace("\\t", "\t");
+                }
+            }
+
+            UnescapeValuesRecursive(dataNode);
 
             obj.DeserializeFromNode(dataNode);
         }

--- a/B9PartSwitch/Fishbones/Parsers/DefaultValueParseMap.cs
+++ b/B9PartSwitch/Fishbones/Parsers/DefaultValueParseMap.cs
@@ -28,7 +28,7 @@ namespace B9PartSwitch.Fishbones.Parsers
         public static readonly IValueParser QuaternionDParser = new ValueParser<QuaternionD>(ConfigNode.ParseQuaternionD, ConfigNode.WriteQuaternion);
         public static readonly IValueParser Vector3dParser = new ValueParser<Vector3d>(ConfigNode.ParseVector3D, ConfigNode.WriteVector);
         public static readonly IValueParser Matrix4x4Parser = new ValueParser<Matrix4x4>(ConfigNode.ParseMatrix4x4, ConfigNode.WriteMatrix4x4);
-        public static readonly IValueParser ColorParser = new ValueParser<Color>(ConfigNode.ParseColor, ConfigNode.WriteColor);
+        public static readonly IValueParser ColorParser = new ValueParser<Color>(Utils.ColorParser.Parse, ConfigNode.WriteColor);
         public static readonly IValueParser Color32Parser = new ValueParser<Color32>(ConfigNode.ParseColor32, ConfigNode.WriteColor);
 
         public static readonly IValueParser AttachNodeParser = new AttachNodeValueParser();

--- a/B9PartSwitch/Localization.cs
+++ b/B9PartSwitch/Localization.cs
@@ -18,6 +18,18 @@ namespace B9PartSwitch
         public static string ModuleB9PartSwitch_DefaultSwitcherDescriptionPlural { get; private set; }
         private static string moduleB9PartSwitch_SelectSubtype;
 
+        public static string SwitcherSubtypeDescriptionGenerator_Resources { get; private set; }
+        public static string SwitcherSubtypeDescriptionGenerator_Mass { get; private set; }
+        public static string SwitcherSubtypeDescriptionGenerator_Cost { get; private set; }
+        public static string SwitcherSubtypeDescriptionGenerator_MaxTemp { get; private set; }
+        public static string SwitcherSubtypeDescriptionGenerator_MaxSkinTemp { get; private set; }
+        public static string SwitcherSubtypeDescriptionGenerator_CrashTolerance { get; private set; }
+        public static string SwitcherSubtypeDescriptionGenerator_TankEmpty { get; private set; }
+        public static string SwitcherSubtypeDescriptionGenerator_TankFull { get; private set; }
+        private static string switcherSubtypeDescriptionGenerator_MassTons;
+        private static string switcherSubtypeDescriptionGenerator_TemperatureKelvins;
+        private static string switcherSubtypeDescriptionGenerator_SpeedMetersPerSecond;
+
         public static string PartSwitchFlightDialog_ResourcesWillBeDumpedWarning(string partName, string switcherDescription)
         {
             return Localizer.Format(partSwitchFlightDialog_ResourcesWillBeDumpedWarning, partName, switcherDescription);
@@ -36,6 +48,21 @@ namespace B9PartSwitch
         public static string ModuleB9PartSwitch_SelectSubtype(string switcherDescription)
         {
             return Localizer.Format(moduleB9PartSwitch_SelectSubtype, switcherDescription);
+        }
+
+        public static string SwitcherSubypeDescriptionGenerator_MassTons(float massTons, string format)
+        {
+            return Localizer.Format(switcherSubtypeDescriptionGenerator_MassTons, massTons.ToString(format));
+        }
+
+        public static string SwitcherSubypeDescriptionGenerator_TemperatureKelvins(float temperatureKelvins, string format)
+        {
+            return Localizer.Format(switcherSubtypeDescriptionGenerator_TemperatureKelvins, temperatureKelvins.ToString(format));
+        }
+
+        public static string SwitcherSubypeDescriptionGenerator_SpeedMetersPerSecond(float speedMetersPerSecond, string format)
+        {
+            return Localizer.Format(switcherSubtypeDescriptionGenerator_SpeedMetersPerSecond, speedMetersPerSecond.ToString(format));
         }
 
         static Localization()
@@ -58,6 +85,18 @@ namespace B9PartSwitch
             ModuleB9PartSwitch_DefaultSwitcherDescription = Localizer.GetStringByTag("#LOC_B9PartSwitch_ModuleB9PartSwitch_default_switcher_description");
             ModuleB9PartSwitch_DefaultSwitcherDescriptionPlural = Localizer.GetStringByTag("#LOC_B9PartSwitch_ModuleB9PartSwitch_default_switcher_description_plural");
             moduleB9PartSwitch_SelectSubtype = Localizer.GetStringByTag("#LOC_B9PartSwitch_ModuleB9PartSwitch_select_subtype");
+
+            SwitcherSubtypeDescriptionGenerator_Resources = Localizer.GetStringByTag("#autoLOC_6001746"); // Resources
+            SwitcherSubtypeDescriptionGenerator_Mass = Localizer.GetStringByTag("#autoLOC_900529"); // Mass
+            SwitcherSubtypeDescriptionGenerator_Cost = Localizer.GetStringByTag("#autoLOC_900528"); // Cost
+            SwitcherSubtypeDescriptionGenerator_MaxTemp = Localizer.GetStringByTag("#LOC_B9PartSwitch_SwitcherSubtypeDescriptionGenerator_max_temp");
+            SwitcherSubtypeDescriptionGenerator_MaxSkinTemp = Localizer.GetStringByTag("#LOC_B9PartSwitch_SwitcherSubtypeDescriptionGenerator_max_skin_temp");
+            SwitcherSubtypeDescriptionGenerator_CrashTolerance = Localizer.GetStringByTag("#LOC_B9PartSwitch_SwitcherSubtypeDescriptionGenerator_crash_tolerance");
+            SwitcherSubtypeDescriptionGenerator_TankEmpty = Localizer.GetStringByTag("#LOC_B9PartSwitch_SwitcherSubtypeDescriptionGenerator_tank_empty");
+            SwitcherSubtypeDescriptionGenerator_TankFull = Localizer.GetStringByTag("#LOC_B9PartSwitch_SwitcherSubtypeDescriptionGenerator_tank_full");
+            switcherSubtypeDescriptionGenerator_MassTons = Localizer.GetStringByTag("#autoLOC_5050023").Replace("<<1>>", "<<1>> "); // <<1>>t // <<1>> t
+            switcherSubtypeDescriptionGenerator_TemperatureKelvins = Localizer.GetStringByTag("#autoLOC_5050037"); // <<1>> m/s
+            switcherSubtypeDescriptionGenerator_SpeedMetersPerSecond = Localizer.GetStringByTag("#autoLOC_5050034"); // <<1>> m/s
         }
     }
 }

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -617,12 +617,11 @@ namespace B9PartSwitch
 
         private void UpdatePartActionWindow()
         {
-            foreach (UIPartActionWindow window in FindObjectsOfType<UIPartActionWindow>())
-            {
-                if (window.part != part) continue;
-                window.ClearList();
-                window.displayDirty = true;
-            }
+            UIPartActionWindow window = UIPartActionController.Instance?.GetItem(part, false);
+            if (window.IsNull()) return;
+
+            window.ClearList();
+            window.displayDirty = true;
         }
 
         private bool IsLastModuleAffectingDragCubes()

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -192,11 +192,11 @@ namespace B9PartSwitch
 
         #region Interface Methods
 
-        public float GetModuleMass(float baseMass, ModifierStagingSituation situation) => CurrentSubtype.TotalMass;
+        public float GetModuleMass(float baseMass, ModifierStagingSituation situation) => GetDryMass(CurrentSubtype);
 
         public ModifierChangeWhen GetModuleMassChangeWhen() => ModifierChangeWhen.FIXED;
 
-        public float GetModuleCost(float baseCost, ModifierStagingSituation situation) => CurrentSubtype.TotalCost;
+        public float GetModuleCost(float baseCost, ModifierStagingSituation situation) =>  GetWetCost(CurrentSubtype);
 
         public ModifierChangeWhen GetModuleCostChangeWhen() => ModifierChangeWhen.FIXED;
 
@@ -208,7 +208,7 @@ namespace B9PartSwitch
             {
                 outStr += $"\n<b>- {subtype.title}</b>";
                 foreach (var resource in subtype.tankType)
-                    outStr += $"\n  <color=#99ff00ff>- {resource.resourceDefinition.displayName}</color>: {resource.unitsPerVolume * subtype.TotalVolume :F1}";
+                    outStr += $"\n  <color=#99ff00ff>- {resource.resourceDefinition.displayName}</color>: {resource.unitsPerVolume * GetTotalVolume(subtype) :F1}";
             }
             return outStr;
         }
@@ -323,6 +323,24 @@ namespace B9PartSwitch
         }
 
         public bool HasPartAspectLock(object partAspectLock) => PartAspectLocks.Contains(partAspectLock);
+
+        public float GetTotalVolume(PartSubtype subtype) => (baseVolume * subtype.volumeMultiplier + subtype.volumeAdded + VolumeFromChildren) * VolumeScale;
+
+        public float GetDryMass(PartSubtype subtype) => GetTotalVolume(subtype) * subtype.tankType.tankMass + subtype.addedMass * VolumeScale;
+
+        public float GetWetMass(PartSubtype subtype) => GetTotalVolume(subtype) * subtype.tankType.TotalUnitMass + subtype.addedMass * VolumeScale;
+
+        public float GetDryCost(PartSubtype subtype) => GetTotalVolume(subtype) * subtype.tankType.tankCost + subtype.addedCost * VolumeScale;
+
+        public float GetWetCost(PartSubtype subtype) => GetTotalVolume(subtype) * subtype.tankType.TotalUnitCost + subtype.addedCost * VolumeScale;
+
+        public float GetParentDryMass(PartSubtype subtype) => parent.IsNull() ? 0 : subtype.volumeAddedToParent * parent.CurrentSubtype.tankType.tankMass * VolumeScale;
+
+        public float GetParentWetMass(PartSubtype subtype) => parent.IsNull() ? 0 : subtype.volumeAddedToParent * parent.CurrentSubtype.tankType.TotalUnitMass * VolumeScale;
+
+        public float GetParentDryCost(PartSubtype subtype) => parent.IsNull() ? 0 : subtype.volumeAddedToParent * parent.CurrentSubtype.tankType.tankCost * VolumeScale;
+
+        public float GetParentWetCost(PartSubtype subtype) => parent.IsNull() ? 0 : subtype.volumeAddedToParent * parent.CurrentSubtype.tankType.TotalUnitCost * VolumeScale;
 
         #endregion
 

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -82,7 +82,7 @@ namespace B9PartSwitch
         #region Private Fields
 
         // Tweakscale integration (set via reflection, readonly is ok)
-        [SuppressMessage("Style", "IDE0044:Add readonly modifier")]
+        [SuppressMessage("Style", "IDE0032", Justification = "Set by Tweakscale")]
         private readonly float scale = 1f;
 
         private ModuleB9PartSwitch parent;

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -64,7 +64,7 @@ namespace B9PartSwitch
 
         // Can't use built-in symmetry because it doesn't know how to find the correct module on the other part
         [KSPField(guiActiveEditor = true, guiName = "Subtype")]
-        [UI_ChooseOption(affectSymCounterparts = UI_Scene.None, scene = UI_Scene.Editor, suppressEditorShipModified = true)]
+        [UI.UI_SubtypeSelector(affectSymCounterparts = UI_Scene.None, scene = UI_Scene.Editor, suppressEditorShipModified = true)]
         public int currentSubtypeIndex = -1;
 
         [KSPField]
@@ -85,7 +85,6 @@ namespace B9PartSwitch
         [SuppressMessage("Style", "IDE0032", Justification = "Set by Tweakscale")]
         private readonly float scale = 1f;
 
-        private ModuleB9PartSwitch parent;
         private List<ModuleB9PartSwitch> children = new List<ModuleB9PartSwitch>(0);
 
         #endregion
@@ -114,7 +113,13 @@ namespace B9PartSwitch
         public bool ManagesTransforms => ManagedTransforms.Any();
         public bool ManagesNodes => ManagedNodes.Any();
         public bool ManagesResources => subtypes.Any(s => !s.tankType.IsStructuralTankType);
+
+        public bool ChangesDryMass => subtypes.Any(s => s.ChangesDryMass);
+        public bool ChangesResourceMass => subtypes.Any(s => s.tankType.ChangesResourceMass);
         public bool ChangesMass => subtypes.Any(s => s.ChangesMass);
+
+        public bool ChangesDryCost => subtypes.Any(s => s.ChangesDryCost);
+        public bool ChangesResourceCost => subtypes.Any(s => s.tankType.ChangesResourceCost);
         public bool ChangesCost => subtypes.Any(s => s.ChangesCost);
 
         public float Scale => scale;
@@ -123,6 +128,8 @@ namespace B9PartSwitch
 
         public IEnumerable<object> PartAspectLocks => subtypes.SelectMany(subtype => subtype.PartAspectLocks);
         public IEnumerable<object> PartAspectLocksOnOtherModules => part.Modules.OfType<ModuleB9PartSwitch>().Where(module => module != this).SelectMany(module => module.PartAspectLocks);
+
+        public ModuleB9PartSwitch Parent { get; private set; }
 
         #endregion
 
@@ -208,7 +215,7 @@ namespace B9PartSwitch
             {
                 outStr += $"\n<b>- {subtype.title}</b>";
                 foreach (var resource in subtype.tankType)
-                    outStr += $"\n  <color=#99ff00ff>- {resource.resourceDefinition.displayName}</color>: {resource.unitsPerVolume * GetTotalVolume(subtype) :F1}";
+                    outStr += $"\n  <color=#99ff00ff>- {resource.resourceDefinition.displayName}</color>: {resource.unitsPerVolume * GetTotalVolume(subtype) :0.#}";
             }
             return outStr;
         }
@@ -334,13 +341,13 @@ namespace B9PartSwitch
 
         public float GetWetCost(PartSubtype subtype) => GetTotalVolume(subtype) * subtype.tankType.TotalUnitCost + subtype.addedCost * VolumeScale;
 
-        public float GetParentDryMass(PartSubtype subtype) => parent.IsNull() ? 0 : subtype.volumeAddedToParent * parent.CurrentSubtype.tankType.tankMass * VolumeScale;
+        public float GetParentDryMass(PartSubtype subtype) => Parent.IsNull() ? 0 : subtype.volumeAddedToParent * Parent.CurrentSubtype.tankType.tankMass * VolumeScale;
 
-        public float GetParentWetMass(PartSubtype subtype) => parent.IsNull() ? 0 : subtype.volumeAddedToParent * parent.CurrentSubtype.tankType.TotalUnitMass * VolumeScale;
+        public float GetParentWetMass(PartSubtype subtype) => Parent.IsNull() ? 0 : subtype.volumeAddedToParent * Parent.CurrentSubtype.tankType.TotalUnitMass * VolumeScale;
 
-        public float GetParentDryCost(PartSubtype subtype) => parent.IsNull() ? 0 : subtype.volumeAddedToParent * parent.CurrentSubtype.tankType.tankCost * VolumeScale;
+        public float GetParentDryCost(PartSubtype subtype) => Parent.IsNull() ? 0 : subtype.volumeAddedToParent * Parent.CurrentSubtype.tankType.tankCost * VolumeScale;
 
-        public float GetParentWetCost(PartSubtype subtype) => parent.IsNull() ? 0 : subtype.volumeAddedToParent * parent.CurrentSubtype.tankType.TotalUnitCost * VolumeScale;
+        public float GetParentWetCost(PartSubtype subtype) => Parent.IsNull() ? 0 : subtype.volumeAddedToParent * Parent.CurrentSubtype.tankType.TotalUnitCost * VolumeScale;
 
         #endregion
 
@@ -350,18 +357,18 @@ namespace B9PartSwitch
 
         private void FindParent()
         {
-            parent = null;
+            Parent = null;
             if (parentID.IsNullOrEmpty()) return;
 
-            parent = part.Modules.OfType<ModuleB9PartSwitch>().FirstOrDefault(module => module.moduleID == parentID);
+            Parent = part.Modules.OfType<ModuleB9PartSwitch>().FirstOrDefault(module => module.moduleID == parentID);
 
-            if (parent.IsNull())
+            if (Parent.IsNull())
             {
                 LogError($"Cannot find parent module with id '{parentID}'");
                 return;
             }
 
-            parent.AddChild(this);
+            Parent.AddChild(this);
         }
 
         private void InitializeSubtypes(bool displayWarnings = true)
@@ -437,9 +444,7 @@ namespace B9PartSwitch
             chooseField.advancedTweakable = advancedTweakablesOnly;
             chooseField.guiActiveEditor = subtypes.Count > 1;
 
-            UI_ChooseOption chooseOption = (UI_ChooseOption)chooseField.uiControlEditor;
-            chooseOption.options = subtypes.Select(s => s.title).ToArray();
-            chooseOption.onFieldChanged = OnSliderUpdate;
+            chooseField.uiControlEditor.onFieldChanged = OnSliderUpdate;
 
             BaseEvent switchSubtypeEvent = Events[nameof(ShowSubtypesWindow)];
             switchSubtypeEvent.guiName = Localization.ModuleB9PartSwitch_SelectSubtype(switcherDescription); // Select <<1>>
@@ -564,7 +569,7 @@ namespace B9PartSwitch
         {
             CurrentSubtype.ActivateOnSwitch();
             UpdateGeometry(false);
-            parent?.UpdateVolume();
+            Parent?.UpdateVolume();
             currentSubtypeTitle = CurrentSubtype.title;
             LogInfo($"Switched subtype to {CurrentSubtype.Name}");
         }

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -104,7 +104,6 @@ namespace B9PartSwitch
         private List<AttachNode> nodes = new List<AttachNode>();
         private List<IPartModifier> partModifiers = new List<IPartModifier>();
         private List<object> aspectLocks = new List<object>();
-        private IVolumeProvider volumeProvider = new ZeroVolumeProvider();
 
         #endregion
 
@@ -118,10 +117,6 @@ namespace B9PartSwitch
         public IEnumerable<AttachNode> Nodes => nodes.All();
         public IEnumerable<string> ResourceNames => tankType.ResourceNames;
         public IEnumerable<string> NodeIDs => nodes.Select(n => n.id);
-
-        public float TotalVolume => volumeProvider?.Volume ?? 0f;
-        public float TotalMass => TotalVolume * tankType.tankMass + addedMass * (parent?.VolumeScale ?? 1f);
-        public float TotalCost => TotalVolume * tankType.TotalUnitCost + addedCost * (parent?.VolumeScale ?? 1f);
 
         public bool ChangesMass => (addedMass != 0f) || tankType.ChangesMass;
         public bool ChangesCost => (addedCost != 0f) || tankType.ChangesCost;
@@ -337,12 +332,11 @@ namespace B9PartSwitch
 
             if (HasTank)
             {
-                volumeProvider = new SubtypeVolumeProvider(parent, volumeMultiplier, volumeAdded);
                 foreach (TankResource resource in tankType)
                 {
                     float filledProportion = (resource.percentFilled ?? percentFilled ?? tankType.percentFilled ?? 100f) * 0.01f;
                     bool? tweakable = resourcesTweakable ?? tankType.resourcesTweakable;
-                    ResourceModifier resourceModifier = new ResourceModifier(resource, volumeProvider, part, filledProportion, tweakable);
+                    ResourceModifier resourceModifier = new ResourceModifier(resource, () => parent.GetTotalVolume(this), part, filledProportion, tweakable);
                     MaybeAddModifier(resourceModifier);
                 }
             }

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -19,6 +19,18 @@ namespace B9PartSwitch
         [NodeData]
         public string title;
 
+        [NodeData]
+        public string descriptionSummary;
+
+        [NodeData]
+        public string descriptionDetail;
+
+        [NodeData]
+        public Color? primaryColor;
+
+        [NodeData]
+        public Color? secondaryColor;
+
         [NodeData(name = "transform")]
         public List<string> transformNames = new List<string>();
 
@@ -118,10 +130,15 @@ namespace B9PartSwitch
         public IEnumerable<string> ResourceNames => tankType.ResourceNames;
         public IEnumerable<string> NodeIDs => nodes.Select(n => n.id);
 
+        public bool ChangesDryMass => addedMass != 0 || tankType.tankMass != 0;
         public bool ChangesMass => (addedMass != 0f) || tankType.ChangesMass;
+        public bool ChangesDryCost => addedCost != 0 || tankType.tankCost != 0;
         public bool ChangesCost => (addedCost != 0f) || tankType.ChangesCost;
 
         public IEnumerable<object> PartAspectLocks => aspectLocks.All();
+
+        public Color PrimaryColor => primaryColor ?? tankType.primaryColor ?? Color.white;
+        public Color SecondaryColor => secondaryColor ?? tankType.secondaryColor ?? primaryColor ?? tankType.primaryColor ?? Color.gray;
 
         #endregion
 

--- a/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
+++ b/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
@@ -8,7 +8,15 @@ namespace B9PartSwitch
     {
         public static void Spawn(ModuleB9PartSwitch module)
         {
-            MaybeCreateResourceRemovalWarning(module, () => CreateDialogue(module));
+            try
+            {
+                MaybeCreateResourceRemovalWarning(module, () => CreateDialogue(module));
+            }
+            catch (Exception ex)
+            {
+                UnityEngine.Debug.LogException(ex);
+                FatalErrorHandler.HandleFatalError(ex);
+            }
         }
 
         private static void MaybeCreateResourceRemovalWarning(ModuleB9PartSwitch module, Action onConfirm)

--- a/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
+++ b/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
@@ -11,7 +11,7 @@ namespace B9PartSwitch
             MaybeCreateResourceRemovalWarning(module, () => CreateDialogue(module));
         }
 
-        public static void MaybeCreateResourceRemovalWarning(ModuleB9PartSwitch module, Action onConfirm)
+        private static void MaybeCreateResourceRemovalWarning(ModuleB9PartSwitch module, Action onConfirm)
         {
             if (HighLogic.LoadedSceneIsFlight && module.CurrentTankType.ResourceNames.Any(name => module.part.Resources[name].amount > 0))
             {

--- a/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
+++ b/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using TMPro;
+using B9PartSwitch.UI;
 
 namespace B9PartSwitch
 {
@@ -49,32 +51,52 @@ namespace B9PartSwitch
 
         private static void CreateDialogue(ModuleB9PartSwitch module)
         {
+            List<Callback> afterCreateCallbacks = new List<Callback>();
             PopupDialog.SpawnPopupDialog(
                 new MultiOptionDialog(
                     "B9PartSwitch_SwitchInFlight",
                     Localization.PartSwitchFlightDialog_SelectNewSubtypeDialogTitle(module.switcherDescription), // Select <<1>>
                     module.part.partInfo.title,
                     HighLogic.UISkin,
-                    CreateOptions(module)
+                    CreateOptions(module, afterCreateCallbacks)
                 ),
                 false,
                 HighLogic.UISkin
             );
+
+            foreach (Callback callback in afterCreateCallbacks)
+            {
+                callback();
+            }
         }
 
-        private static DialogGUIBase[] CreateOptions(ModuleB9PartSwitch module)
+        private static DialogGUIBase[] CreateOptions(ModuleB9PartSwitch module, IList<Callback> afterCreateCallbacks)
         {
             List<DialogGUIBase> options = new List<DialogGUIBase>();
+
+            SwitcherSubtypeDescriptionGenerator subtypeDescriptionGenerator = new SwitcherSubtypeDescriptionGenerator(module);
 
             foreach (PartSubtype subtype in module.subtypes)
             {
                 if (subtype == module.CurrentSubtype)
                 {
-                    options.Add(new DialogGUILabel(Localization.PartSwitchFlightDialog_CurrentSubtypeLabel(subtype.title), HighLogic.UISkin.button)); // <<1>> (Current)
+                    string currentSubtypeText = Localization.PartSwitchFlightDialog_CurrentSubtypeLabel(subtype.title);  // <<1>> (Current)
+                    DialogGUILabel label = new DialogGUILabel(currentSubtypeText, HighLogic.UISkin.button);
+                    afterCreateCallbacks.Add(delegate
+                    {
+                        if (!(label.uiItem.GetComponent<TextMeshProUGUI>() is TextMeshProUGUI textUI))
+                            throw new Exception("Could not find TextMeshProUGUI");
+                        else
+                            textUI.raycastTarget = true;
+                    });
+                    afterCreateCallbacks.Add(() => TooltipHelper.SetupSubtypeInfoTooltip(label.uiItem, subtype.title, subtypeDescriptionGenerator.GetFullSubtypeDescription(subtype)));
+                    options.Add(label);
                 }
                 else if (HighLogic.LoadedSceneIsEditor || subtype.allowSwitchInFlight)
                 {
-                    options.Add(new DialogGUIButton(subtype.title, () => module.SwitchSubtype(subtype.Name)));
+                    DialogGUIButton button = new DialogGUIButton(subtype.title, () => module.SwitchSubtype(subtype.Name));
+                    afterCreateCallbacks.Add(() => TooltipHelper.SetupSubtypeInfoTooltip(button.uiItem, subtype.title, subtypeDescriptionGenerator.GetFullSubtypeDescription(subtype)));
+                    options.Add(button);
                 }
             }
 

--- a/B9PartSwitch/TankSettings/Tanks.cs
+++ b/B9PartSwitch/TankSettings/Tanks.cs
@@ -73,7 +73,9 @@ namespace B9PartSwitch
 
         public bool IsStructuralTankType => (tankName == B9TankSettings.structuralTankName) && (tankMass == 0f) && (tankCost == 0f) && (resources.Count == 0);
 
+        public float ResourceUnitMass => resources.Sum(r => r.unitsPerVolume * r.resourceDefinition.density);
         public float ResourceUnitCost => resources.Sum(r => r.unitsPerVolume * r.resourceDefinition.unitCost);
+        public float TotalUnitMass => ResourceUnitMass + tankMass;
         public float TotalUnitCost => ResourceUnitCost + tankCost;
 
         public bool ChangesMass => (tankMass != 0f) || resources.Any(r => r.resourceDefinition.density != 0);

--- a/B9PartSwitch/TankSettings/Tanks.cs
+++ b/B9PartSwitch/TankSettings/Tanks.cs
@@ -76,8 +76,8 @@ namespace B9PartSwitch
         public float ResourceUnitCost => resources.Sum(r => r.unitsPerVolume * r.resourceDefinition.unitCost);
         public float TotalUnitCost => ResourceUnitCost + tankCost;
 
-        public bool ChangesMass => (tankMass != 0f) || (resources.Any(r => r.resourceDefinition.density != 0f));
-        public bool ChangesCost => (tankCost != 0f) || (resources.Any(r => r.resourceDefinition.unitCost != 0f));
+        public bool ChangesMass => (tankMass != 0f) || resources.Any(r => r.resourceDefinition.density != 0);
+        public bool ChangesCost => (tankCost != 0f) || resources.Any(r => r.resourceDefinition.unitCost != 0);
 
         #endregion
 

--- a/B9PartSwitch/TankSettings/Tanks.cs
+++ b/B9PartSwitch/TankSettings/Tanks.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UniLinq;
+using UnityEngine;
 using B9PartSwitch.Fishbones;
 using B9PartSwitch.Fishbones.Context;
 
@@ -43,6 +44,12 @@ namespace B9PartSwitch
         public string tankName;
 
         [NodeData]
+        public Color? primaryColor;
+
+        [NodeData]
+        public Color? secondaryColor;
+
+        [NodeData]
         public float tankMass = 0f;
 
         [NodeData]
@@ -78,8 +85,10 @@ namespace B9PartSwitch
         public float TotalUnitMass => ResourceUnitMass + tankMass;
         public float TotalUnitCost => ResourceUnitCost + tankCost;
 
-        public bool ChangesMass => (tankMass != 0f) || resources.Any(r => r.resourceDefinition.density != 0);
-        public bool ChangesCost => (tankCost != 0f) || resources.Any(r => r.resourceDefinition.unitCost != 0);
+        public bool ChangesResourceMass => resources.Any(r => r.resourceDefinition.density != 0);
+        public bool ChangesMass => (tankMass != 0f) || ChangesResourceMass;
+        public bool ChangesResourceCost => resources.Any(r => r.resourceDefinition.unitCost != 0);
+        public bool ChangesCost => (tankCost != 0f) || ChangesResourceCost;
 
         #endregion
 

--- a/B9PartSwitch/TankSettings/Tanks.cs
+++ b/B9PartSwitch/TankSettings/Tanks.cs
@@ -5,6 +5,7 @@ using UniLinq;
 using UnityEngine;
 using B9PartSwitch.Fishbones;
 using B9PartSwitch.Fishbones.Context;
+using B9PartSwitch.Utils;
 
 namespace B9PartSwitch
 {
@@ -92,7 +93,12 @@ namespace B9PartSwitch
 
         #endregion
 
-        public void Load(ConfigNode node, OperationContext context) => this.LoadFields(node, context);
+        public void Load(ConfigNode node, OperationContext context)
+        {
+            this.LoadFields(node, context);
+            OnLoad();
+        }
+
         public void Save(ConfigNode node, OperationContext context) => this.SaveFields(node, context);
 
         public List<TankResource>.Enumerator GetEnumerator() => resources.GetEnumerator();
@@ -111,6 +117,65 @@ namespace B9PartSwitch
                     outStr += "Null Tank Resource";
             }
             return outStr;
+        }
+
+        private void OnLoad()
+        {
+            SetDefaultColors();
+        }
+
+        private void SetDefaultColors()
+        {
+            if (primaryColor.IsNotNull() || secondaryColor.IsNotNull()) return;
+
+            if (resources.Count == 1 && resources[0].ResourceName == "LiquidFuel")
+            {
+                primaryColor = ResourceColors.LiquidFuel;
+            }
+            else if (resources.Count == 2 && resources[0].ResourceName == "LiquidFuel" && resources[1].ResourceName == "Oxidizer")
+            {
+                primaryColor = ResourceColors.LiquidFuel;
+                secondaryColor = ResourceColors.Oxidizer;
+            }
+            else if (resources.Count == 1 && resources[0].ResourceName == "MonoPropellant")
+            {
+                primaryColor = ResourceColors.MonoPropellant;
+            }
+            else if (resources.Count == 1 && resources[0].ResourceName == "ElectricCharge")
+            {
+                primaryColor = ResourceColors.ElectricChargePrimary;
+                secondaryColor = ResourceColors.ElectricChargeSecondary;
+            }
+            else if (resources.Count == 1 && resources[0].ResourceName == "LqdHydrogen")
+            {
+                primaryColor = ResourceColors.LqdHydrogen;
+            }
+            else if (resources.Count == 2 && resources[0].ResourceName == "LqdHydrogen" && resources[1].ResourceName == "Oxidizer")
+            {
+                primaryColor = ResourceColors.LqdHydrogen;
+                secondaryColor = ResourceColors.Oxidizer;
+            }
+            else if (resources.Count == 1 && resources[0].ResourceName == "LqdMethane")
+            {
+                primaryColor = ResourceColors.LqdMethane;
+            }
+            else if (resources.Count == 2 && resources[0].ResourceName == "LqdMethane" && resources[1].ResourceName == "Oxidizer")
+            {
+                primaryColor = ResourceColors.LqdMethane;
+                secondaryColor = ResourceColors.Oxidizer;
+            }
+            else if (resources.Count == 1 && resources[0].ResourceName == "Oxidizer")
+            {
+                primaryColor = ResourceColors.Oxidizer;
+            }
+            else if (resources.Count == 1 && resources[0].ResourceName == "XenonGas")
+            {
+                primaryColor = ResourceColors.XenonGas;
+            }
+            else if (resources.Count == 1 && resources[0].ResourceName == "Ore")
+            {
+                primaryColor = ResourceColors.Ore;
+            }
         }
     }
 }

--- a/B9PartSwitch/UI/PrefabManager.cs
+++ b/B9PartSwitch/UI/PrefabManager.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using UnityEngine;
+
+namespace B9PartSwitch.UI
+{
+    [KSPAddon(KSPAddon.Startup.Instantly, true)]
+    public class PrefabManagerInstant : MonoBehaviour
+    {
+        [SuppressMessage("Code Quality", "IDE0051", Justification = "Called by Unity")]
+        private void Awake()
+        {
+            Debug.Log("[B9PartSwitch.UI.PrefabManagerInstant] awake");
+
+            try
+            {
+                TooltipHelper.EnsurePrefabs();
+            }
+            catch (Exception ex)
+            {
+                FatalErrorHandler.HandleFatalError(ex);
+                Debug.LogException(ex);
+            }
+
+            Destroy(gameObject);
+        }
+
+    }
+
+    [KSPAddon(KSPAddon.Startup.EditorAny, false)]
+    public class PrefabManagerEditor : MonoBehaviour
+    {
+        [SuppressMessage("Code Quality", "IDE0051", Justification = "Called by Unity")]
+        private void Start()
+        {
+            Debug.Log("[B9PartSwitch.UI.PrefabManagerEditor] start");
+
+            if (HighLogic.LoadedSceneIsEditor || HighLogic.LoadedSceneIsFlight)
+            {
+                try
+                {
+                    UIPartActionSubtypeSelector.EnsurePrefab();
+                }
+                catch (Exception ex)
+                {
+                    FatalErrorHandler.HandleFatalError(ex);
+                    Debug.LogException(ex);
+                }
+            }
+
+            Destroy(gameObject);
+        }
+    }
+}

--- a/B9PartSwitch/UI/SwitcherSubtypeDescriptionGenerator.cs
+++ b/B9PartSwitch/UI/SwitcherSubtypeDescriptionGenerator.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+using static B9PartSwitch.Localization;
+using GroupedStringBuilder = B9PartSwitch.Utils.GroupedStringBuilder;
+
+namespace B9PartSwitch.UI
+{
+    public class SwitcherSubtypeDescriptionGenerator
+    {
+        private const string BAD_CHANGE_COLOR = "#ff3f3f";
+        private const string GOOD_CHANGE_COLOR = "#3fff3f";
+
+        private static readonly GroupedStringBuilder stringBuilder = new GroupedStringBuilder();
+        private static readonly object lockObject = new object();
+
+        private readonly ModuleB9PartSwitch module;
+
+        private readonly float partDryMass, partWetMass, partDryCost, partWetCost, baseDryMass, baseWetMass, baseDryCost, baseWetCost;
+        private readonly bool showDryMass, showWetMass, showDryCost, showWetCost, showMaxTemp, showSkinMaxTemp, showCrashTolerance;
+        private readonly float prefabMaxTemp, prefabSkinMaxTemp, prefabCrashTolerance, currentMaxTemp, currentSkinMaxTemp, currentCrashTolerance;
+
+        private readonly KeyValuePair<TankResource, float>[] parentResources;
+        private readonly float baseParentVolume;
+
+        public SwitcherSubtypeDescriptionGenerator(ModuleB9PartSwitch module)
+        {
+            module.ThrowIfNullArgument(nameof(module));
+            this.module = module;
+
+            Part partPrefab = module.part.GetPrefab();
+
+            float prefabMass = partPrefab.mass;
+            partDryMass = prefabMass + module.part.GetModuleMass(prefabMass);
+            partWetMass = partDryMass + module.part.GetResourceMassMax();
+
+            baseDryMass = partDryMass - module.GetDryMass(module.CurrentSubtype) - module.GetParentDryMass(module.CurrentSubtype);
+            baseWetMass = partWetMass - module.GetWetMass(module.CurrentSubtype) - module.GetParentWetMass(module.CurrentSubtype);
+
+            float prefabCost = module.part.partInfo.cost;
+            partWetCost = prefabCost + module.part.GetModuleCosts(prefabCost);
+            partDryCost = partWetCost - module.part.GetResourceCostMax();
+
+            baseDryCost = partDryCost - module.GetDryCost(module.CurrentSubtype) - module.GetParentDryCost(module.CurrentSubtype);
+            baseWetCost = partWetCost - module.GetWetCost(module.CurrentSubtype) - module.GetParentWetCost(module.CurrentSubtype);
+
+            showWetMass = module.ChangesResourceMass;
+            showWetMass |= module.Parent?.CurrentTankType.ChangesResourceMass ?? false;
+
+            showDryMass = showWetMass;
+            showDryMass |= module.ChangesDryMass;
+            showDryMass |= (module.Parent?.CurrentTankType.tankMass ?? 0) != 0;
+
+            showWetCost = module.ChangesResourceCost;
+            showWetCost |= module.Parent?.CurrentTankType.ChangesResourceCost ?? false;
+
+            showDryCost = showWetCost;
+            showDryCost |= module.ChangesDryCost;
+            showDryCost |= (module.Parent?.CurrentTankType.tankCost ?? 0) != 0;
+
+            showMaxTemp = module.HasPartAspectLock("maxTemp");
+            showSkinMaxTemp = module.HasPartAspectLock("skinMaxTemp");
+            showCrashTolerance = module.HasPartAspectLock("crashTolerance");
+
+            prefabMaxTemp = (float)partPrefab.maxTemp;
+            prefabSkinMaxTemp = (float)partPrefab.skinMaxTemp;
+            prefabCrashTolerance = partPrefab.crashTolerance;
+
+            currentMaxTemp = (float)module.part.maxTemp;
+            currentSkinMaxTemp = (float)module.part.skinMaxTemp;
+            currentCrashTolerance = module.part.crashTolerance;
+
+            float currentParentVolume = module.Parent?.GetTotalVolume(module.Parent.CurrentSubtype) ?? 0;
+            baseParentVolume = currentParentVolume - (module.CurrentSubtype.volumeAddedToParent * module.VolumeScale);
+
+            parentResources = new KeyValuePair<TankResource, float>[module.Parent?.CurrentTankType.resources.Count ?? 0];
+
+            for (int i = 0; i < parentResources.Length; i++)
+            {
+                TankResource resource = module.Parent.CurrentTankType[i];
+                parentResources[i] = new KeyValuePair<TankResource, float>(resource, resource.unitsPerVolume * currentParentVolume);
+            }
+        }
+
+        public string GetFullSubtypeDescription(PartSubtype subtype)
+        {
+            lock (lockObject)
+            {
+                try
+                {
+                    GetFullSubtypeDescriptionInternal(subtype);
+                    string result = stringBuilder.ToString();
+                    int leadingWhitespace = result.Length - result.TrimStart().Length;
+                    int trailingWhitespace = result.Length - result.TrimEnd().Length;
+                    if (leadingWhitespace != 0)
+                        Debug.LogError("[SwitcherSubtypeDescriptionGenerator] decription has leading whitespace: " + leadingWhitespace);
+                    if (trailingWhitespace != 0)
+                        Debug.LogError("[SwitcherSubtypeDescriptionGenerator] decription has trailing whitespace: " + trailingWhitespace);
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                    return "<color=orange><b>error generating description</b></color>\n\nhere's some placeholder text instead";
+                }
+                finally
+                {
+                    stringBuilder.Clear();
+                }
+            }
+        }
+
+        private void GetFullSubtypeDescriptionInternal(PartSubtype subtype)
+        {
+            if (!subtype.descriptionSummary.IsNullOrEmpty())
+            {
+                stringBuilder.AppendLine(subtype.descriptionSummary);
+            }
+
+            stringBuilder.BeginGroup();
+
+            if (subtype.tankType.resources.Count > 0 || parentResources.Length > 0)
+            {
+                stringBuilder.AppendLine("<b>{0}:</b>", SwitcherSubtypeDescriptionGenerator_Resources);
+                foreach (TankResource resource in subtype.tankType)
+                    stringBuilder.AppendLine("  <color=#bfff3f>- {0}</color>: {1:0.#}", resource.resourceDefinition.displayName, resource.unitsPerVolume * module.GetTotalVolume(subtype));
+
+                float parentVolume = baseParentVolume + (subtype.volumeAddedToParent * module.VolumeScale);
+
+                foreach (KeyValuePair<TankResource, float> resourceAndAmount in parentResources)
+                {
+                    float amount = resourceAndAmount.Key.unitsPerVolume * parentVolume;
+                    float difference = amount - resourceAndAmount.Value;
+                    stringBuilder.Append("  <color=#bfff3f>- {0}</color>: {1:0.#}", resourceAndAmount.Key.resourceDefinition.displayName, amount);
+                    if (!ApproximatelyZero(difference)) stringBuilder.Append(FormatResourceDifference(difference));
+                    stringBuilder.AppendLine();
+                }
+            }
+
+            float dryMass = baseDryMass + module.GetDryMass(subtype) + module.GetParentDryMass(subtype);
+            float wetMass = baseWetMass + module.GetWetMass(subtype) + module.GetParentWetMass(subtype);
+
+            float dryMassDifference = dryMass - partDryMass;
+            float wetMassDifference = wetMass - partWetMass;
+
+            float dryCost = baseDryCost + module.GetDryCost(subtype) + module.GetParentDryCost(subtype);
+            float wetCost = baseWetCost + module.GetWetCost(subtype) + module.GetParentWetCost(subtype);
+
+            float dryCostDifference = dryCost - partDryCost;
+            float wetCostDifference = wetCost - partWetCost;
+
+            stringBuilder.BeginGroup();
+
+            if (showWetMass)
+            {
+                stringBuilder.Append("<b>{0}:</b> {1} {2}", SwitcherSubtypeDescriptionGenerator_Mass, SwitcherSubypeDescriptionGenerator_MassTons(dryMass, "0.###"), SwitcherSubtypeDescriptionGenerator_TankEmpty);
+                if (!ApproximatelyZero(dryMassDifference) && !ApproximatelyEqual(dryMassDifference, wetMassDifference)) stringBuilder.Append(FormatMassDifference(dryMassDifference));
+                stringBuilder.Append(" / {0} {1}", SwitcherSubypeDescriptionGenerator_MassTons(wetMass, "0.###"), SwitcherSubtypeDescriptionGenerator_TankFull);
+                if (!ApproximatelyZero(wetMassDifference)) stringBuilder.Append(FormatMassDifference(wetMassDifference));
+                stringBuilder.AppendLine();
+            }
+            else if (showDryMass)
+            {
+                stringBuilder.Append("<b>{0}:</b> {1}", SwitcherSubtypeDescriptionGenerator_Mass, SwitcherSubypeDescriptionGenerator_MassTons(dryMass, "0.###"));
+                if (!ApproximatelyZero(dryMassDifference)) stringBuilder.Append(FormatMassDifference(dryMassDifference));
+                stringBuilder.AppendLine();
+            }
+
+            if (showWetCost)
+            {
+                stringBuilder.Append("<b>{0}:</b> {1:0.#} {2}", SwitcherSubtypeDescriptionGenerator_Cost, dryCost, SwitcherSubtypeDescriptionGenerator_TankEmpty);
+                if (!ApproximatelyZero(dryCostDifference) && !ApproximatelyEqual(dryCostDifference, wetCostDifference)) stringBuilder.Append(FormatCostDifference(dryCostDifference));
+                stringBuilder.Append(" / {0:0.#} {1}", wetCost, SwitcherSubtypeDescriptionGenerator_TankFull);
+                if (!ApproximatelyZero(wetCostDifference)) stringBuilder.Append(FormatCostDifference(wetCostDifference));
+                stringBuilder.AppendLine();
+            }
+            else if (showDryCost)
+            {
+                stringBuilder.Append("<b>{0}:</b> {1:#.#}", SwitcherSubtypeDescriptionGenerator_Cost, dryCost);
+                if (!ApproximatelyZero(dryCostDifference)) stringBuilder.Append(FormatCostDifference(dryCostDifference));
+                stringBuilder.AppendLine();
+            }
+
+            if (showMaxTemp)
+            {
+                float maxTemp = subtype.maxTemp > 0 ? subtype.maxTemp : prefabMaxTemp;
+                stringBuilder.Append("<b>{0}:</b> {1}", SwitcherSubtypeDescriptionGenerator_MaxTemp, SwitcherSubypeDescriptionGenerator_TemperatureKelvins(maxTemp, "#"));
+                if (!ApproximatelyEqual(maxTemp, currentMaxTemp)) stringBuilder.Append(FormatTemperatureDifference(maxTemp - currentMaxTemp));
+                stringBuilder.AppendLine();
+            }
+
+            if (showSkinMaxTemp)
+            {
+                float skinMaxTemp = subtype.skinMaxTemp > 0 ? subtype.skinMaxTemp : prefabSkinMaxTemp;
+                stringBuilder.Append("<b>{0}:</b> {1}", SwitcherSubtypeDescriptionGenerator_MaxSkinTemp, SwitcherSubypeDescriptionGenerator_TemperatureKelvins(skinMaxTemp, "#"));
+                if (!ApproximatelyEqual(skinMaxTemp, currentSkinMaxTemp)) stringBuilder.Append(FormatTemperatureDifference(skinMaxTemp - currentSkinMaxTemp));
+                stringBuilder.AppendLine();
+            }
+
+            if (showCrashTolerance)
+            {
+                float crashTolerance = subtype.crashTolerance > 0 ? subtype.crashTolerance : prefabCrashTolerance;
+                stringBuilder.Append("<b>{0}:</b> {1}", SwitcherSubtypeDescriptionGenerator_CrashTolerance, SwitcherSubypeDescriptionGenerator_SpeedMetersPerSecond(crashTolerance, "#"));
+                if (!ApproximatelyEqual(crashTolerance, currentCrashTolerance)) stringBuilder.Append(FormatSpeedDifference(crashTolerance - currentCrashTolerance));
+                stringBuilder.AppendLine();
+            }
+
+            stringBuilder.BeginGroup();
+
+            if (!subtype.descriptionDetail.IsNullOrEmpty())
+            {
+                stringBuilder.AppendLine(subtype.descriptionDetail);
+            }
+        }
+
+        private static bool ApproximatelyEqual(float a, float b)
+        {
+            return (a == b) || Mathf.Abs(a - b) < 1e-4;
+        }
+
+        private static bool ApproximatelyZero(float a) => ApproximatelyEqual(a, 0);
+
+        private static string FormatMassDifference(float massDifference)
+        {
+            string color = massDifference > 0 ? BAD_CHANGE_COLOR : GOOD_CHANGE_COLOR;
+            string formattedValue = SwitcherSubypeDescriptionGenerator_MassTons(massDifference, "+0.###;-0.###");
+            return $" (<color={color}>{formattedValue}</color>)";
+        }
+
+        private static string FormatCostDifference(float costDifference)
+        {
+            string color = costDifference > 0 ? BAD_CHANGE_COLOR : GOOD_CHANGE_COLOR;
+            string formattedValue = costDifference.ToString("+0.#;-0.#");
+            return $" (<color={color}>{formattedValue}</color>)";
+        }
+
+        private static string FormatTemperatureDifference(float temperatureDifference)
+        {
+            string color = temperatureDifference > 0 ? GOOD_CHANGE_COLOR : BAD_CHANGE_COLOR;
+            string formattedValue = SwitcherSubypeDescriptionGenerator_TemperatureKelvins(temperatureDifference, "+#;-#");
+            return $" (<color={color}>{formattedValue}</color>)";
+        }
+
+        private static string FormatSpeedDifference(float speedDifference)
+        {
+            string color = speedDifference > 0 ? GOOD_CHANGE_COLOR : BAD_CHANGE_COLOR;
+            string formattedValue = SwitcherSubypeDescriptionGenerator_SpeedMetersPerSecond(speedDifference, "+#;-#");
+            return $" (<color={color}>{formattedValue}</color>)";
+        }
+
+        private static string FormatResourceDifference(float resourceDifference)
+        {
+            string color = resourceDifference > 0 ? GOOD_CHANGE_COLOR : BAD_CHANGE_COLOR;
+            return $" (<color={color}>{resourceDifference:+0.#;-0.#}</color>)";
+        }
+    }
+}

--- a/B9PartSwitch/UI/TooltipHelper.cs
+++ b/B9PartSwitch/UI/TooltipHelper.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using UnityEngine;
+using KSP.UI;
+using KSP.UI.TooltipTypes;
+
+namespace B9PartSwitch.UI
+{
+    public static class TooltipHelper
+    {
+        private static Tooltip subtypeInfoTooltip;
+
+        public static void EnsurePrefabs()
+        {
+            if (subtypeInfoTooltip.IsNotNull()) return;
+
+            subtypeInfoTooltip = CreateSubtypeInfoTooltipPrefab();
+            Debug.Log("[B9PartSwitch.UI.TooltipHelper] created subtype info tooltip prefab");
+
+        }
+
+        public static TooltipController_TitleAndText SetupSubtypeInfoTooltip(GameObject gameObject, string titleString, string textString)
+        {
+            TooltipController_TitleAndText tooltipController = gameObject.AddOrGetComponent<TooltipController_TitleAndText>();
+            tooltipController.TooltipPrefabType = subtypeInfoTooltip;
+
+            tooltipController.titleString = titleString;
+            tooltipController.textString = textString;
+            return tooltipController;
+        }
+
+        public static void SetupSubtypeInfoTooltip(TooltipController_TitleAndText tooltipController, string titleString, string textString)
+        {
+            tooltipController.TooltipPrefabType = subtypeInfoTooltip;
+
+            tooltipController.titleString = titleString;
+            tooltipController.textString = textString;
+        }
+
+        private static Tooltip CreateSubtypeInfoTooltipPrefab()
+        {
+            Tooltip tooltipPrefab_TitleAndText = AssetBase.GetPrefab<Tooltip>("Tooltip_TitleAndText");
+            GameObject subtypeInfoTooltipPrefabGameObject = UnityEngine.Object.Instantiate(tooltipPrefab_TitleAndText.gameObject);
+            UnityEngine.Object.DontDestroyOnLoad(subtypeInfoTooltipPrefabGameObject);
+            subtypeInfoTooltipPrefabGameObject.GetChild("Text").GetComponent<TMPro.TextMeshProUGUI>().alpha = 0.9f;
+            subtypeInfoTooltipPrefabGameObject.GetChild("Title").GetComponent<UnityEngine.UI.LayoutElement>().minWidth = 300;
+
+            return subtypeInfoTooltipPrefabGameObject.GetComponent<Tooltip>();
+        }
+    }
+}

--- a/B9PartSwitch/UI/UIPartActionSubtypeButton.cs
+++ b/B9PartSwitch/UI/UIPartActionSubtypeButton.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using KSP.UI.TooltipTypes;
+
+namespace B9PartSwitch.UI
+{
+    public class UIPartActionSubtypeButton : MonoBehaviour, IEventSystemHandler
+    {
+        [SerializeField]
+        private Image imagePrimaryColor;
+
+        [SerializeField]
+        private Image imageSecondaryColor;
+
+        [SerializeField]
+        private Image imageSelected;
+
+        [SuppressMessage("Code Quality", "IDE0052", Justification = "Reserved for future use")]
+        [SerializeField]
+        private Image imageInvalid;
+
+        [SerializeField]
+        private Button buttonMain;
+
+        [SerializeField]
+        private TooltipController_TitleAndText tooltipController;
+
+        public UIPartActionSubtypeButton previousItem;
+        public UIPartActionSubtypeButton nextItem;
+
+        public string Title { get; private set; }
+        public string Description { get; private set; }
+
+        private Callback setSubtype;
+
+        public static GameObject CreatePrefab(GameObject variantButtonGameObject)
+        {
+            GameObject partActionVariantButtonGameObject = Instantiate(variantButtonGameObject);
+            DontDestroyOnLoad(partActionVariantButtonGameObject);
+
+            UIPartActionVariantButton partActionVariantButton = partActionVariantButtonGameObject.GetComponent<UIPartActionVariantButton>();
+            UIPartActionSubtypeButton partActionSubtypeButton = partActionVariantButtonGameObject.AddComponent<UIPartActionSubtypeButton>();
+
+            partActionSubtypeButton.imagePrimaryColor = partActionVariantButton.imagePrimaryColor;
+            partActionSubtypeButton.imageSecondaryColor = partActionVariantButton.imageSecomdaryColor;
+            partActionSubtypeButton.imageSelected = partActionVariantButton.imageSelected;
+            partActionSubtypeButton.imageInvalid = partActionVariantButton.imageInvalid;
+            partActionSubtypeButton.buttonMain = partActionVariantButton.buttonMain;
+            partActionSubtypeButton.tooltipController = partActionVariantButtonGameObject.AddComponent<TooltipController_TitleAndText>();
+
+            Destroy(partActionVariantButton);
+
+            return partActionVariantButtonGameObject;
+        }
+
+        public void Setup(string title, string description, Color primaryColor, Color secondaryColor, Callback setSubtype)
+        {
+            Title = title;
+            Description = description;
+
+            imagePrimaryColor.color = primaryColor;
+            imageSecondaryColor.color = secondaryColor;
+
+            TooltipHelper.SetupSubtypeInfoTooltip(tooltipController, title, description);
+
+            buttonMain.onClick.AddListener(ButtonClick);
+
+            this.setSubtype = setSubtype;
+        }
+
+        public void SetSubtype() => setSubtype();
+
+        public void Activate() => imageSelected.gameObject.SetActive(true);
+
+        public void Deactivate() => imageSelected.gameObject.SetActive(false);
+
+        private void ButtonClick() => setSubtype();
+    }
+}

--- a/B9PartSwitch/UI/UIPartActionSubtypeSelector.cs
+++ b/B9PartSwitch/UI/UIPartActionSubtypeSelector.cs
@@ -1,0 +1,190 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using KSP.UI.TooltipTypes;
+
+namespace B9PartSwitch.UI
+{
+    [UI_SubtypeSelector]
+    public class UIPartActionSubtypeSelector : UIPartActionFieldItem
+    {
+        private static UIPartActionSubtypeSelector partActionSubtypeSelectorPrefab;
+
+        [SerializeField]
+        private GameObject prefabVariantButton;
+
+        [SerializeField]
+        private Button buttonPrevious;
+
+        [SerializeField]
+        private Button buttonNext;
+
+        [SerializeField]
+        private ScrollRect scrollMain;
+
+        [SerializeField]
+        private TextMeshProUGUI switcherDescriptionText;
+
+        [SerializeField]
+        private TextMeshProUGUI subtypeTitleText;
+
+        [SerializeField]
+        private TooltipController_TitleAndText buttonPreviousTooltipController;
+
+        [SerializeField]
+        private TooltipController_TitleAndText buttonNextTooltipController;
+
+        private List<UIPartActionSubtypeButton> subtypeButtons;
+
+        public static void EnsurePrefab()
+        {
+            if (UIPartActionController.Instance.IsNull()) throw new InvalidOperationException("UIPartActionController.Instance is null");
+
+            if (partActionSubtypeSelectorPrefab.IsNull()) partActionSubtypeSelectorPrefab = CreatePrefab();
+            else if (UIPartActionController.Instance.fieldPrefabs.Contains(partActionSubtypeSelectorPrefab)) return;
+
+            UIPartActionController.Instance.fieldPrefabs.Add(partActionSubtypeSelectorPrefab);
+            Debug.Log("[B9PartSwitch.UI.UIPartActionSubtypeSelector] added prefab to UIPartActionController");
+        }
+
+        public override void Setup(UIPartActionWindow window, Part part, PartModule partModule, UI_Scene scene, UI_Control control, BaseField field)
+        {
+            base.Setup(window, part, partModule, scene, control, field);
+
+            ModuleB9PartSwitch switcherModule = (ModuleB9PartSwitch)partModule;
+
+            SwitcherSubtypeDescriptionGenerator subtypeDescriptionGenerator = new SwitcherSubtypeDescriptionGenerator(switcherModule);
+
+            subtypeButtons = new List<UIPartActionSubtypeButton>(switcherModule.subtypes.Count);
+            for (int i = 0; i < switcherModule.subtypes.Count; i++)
+            {
+                PartSubtype subtype = switcherModule.subtypes[i];
+                GameObject buttonGameObject = Instantiate(prefabVariantButton, scrollMain.content);
+                UIPartActionSubtypeButton subtypeButton = buttonGameObject.GetComponent<UIPartActionSubtypeButton>();
+
+                // prevent capturing in closures
+                int index = i;
+
+                subtypeButton.Setup(
+                    subtype.title,
+                    subtypeDescriptionGenerator.GetFullSubtypeDescription(subtype),
+                    subtype.PrimaryColor,
+                    subtype.SecondaryColor,
+                    () => SetSubtype(index)
+                );
+
+                subtypeButtons.Add(subtypeButton);
+            }
+
+            subtypeButtons[0].previousItem = subtypeButtons[subtypeButtons.Count - 1];
+            subtypeButtons[0].nextItem = subtypeButtons[1];
+            for (int i = 1; i < subtypeButtons.Count - 1; i++)
+            {
+                subtypeButtons[i].previousItem = subtypeButtons[i - 1];
+                subtypeButtons[i].nextItem = subtypeButtons[i + 1];
+            }
+            subtypeButtons[subtypeButtons.Count - 1].previousItem = subtypeButtons[subtypeButtons.Count - 2];
+            subtypeButtons[subtypeButtons.Count - 1].nextItem = subtypeButtons[0];
+
+            switcherDescriptionText.text = switcherModule.switcherDescription;
+
+            TooltipHelper.SetupSubtypeInfoTooltip(buttonPreviousTooltipController, "", "");
+            TooltipHelper.SetupSubtypeInfoTooltip(buttonNextTooltipController, "", "");
+
+            SetTooltips(switcherModule.currentSubtypeIndex);
+
+            buttonPrevious.onClick.AddListener(PreviousSubtype);
+            buttonNext.onClick.AddListener(NextSubtype);
+
+            subtypeTitleText.text = switcherModule.CurrentSubtype.title;
+
+            subtypeButtons[switcherModule.currentSubtypeIndex].Activate();
+        }
+
+        public override void UpdateItem()
+        {
+            transform.SetAsLastSibling();
+        }
+
+        private void PreviousSubtype()
+        {
+            int currentIndex = field.GetValue<int>(field.host);
+            subtypeButtons[currentIndex].previousItem.SetSubtype();
+        }
+
+        private void NextSubtype()
+        {
+            int currentIndex = field.GetValue<int>(field.host);
+            subtypeButtons[currentIndex].nextItem.SetSubtype();
+        }
+
+        private void SetSubtype(int newIndex)
+        {
+            int currentIndex = field.GetValue<int>(field.host);
+            if (newIndex == currentIndex) return;
+
+            subtypeButtons[currentIndex].Deactivate();
+            subtypeButtons[newIndex].Activate();
+            subtypeTitleText.text = subtypeButtons[newIndex].Title;
+
+            SetTooltips(newIndex);
+
+            SetFieldValue(newIndex);
+        }
+
+        private void SetTooltips(int index)
+        {
+            buttonPreviousTooltipController.titleString = subtypeButtons[index].previousItem.Title;
+            buttonPreviousTooltipController.textString = subtypeButtons[index].previousItem.Description;
+
+            buttonNextTooltipController.titleString = subtypeButtons[index].nextItem.Title;
+            buttonNextTooltipController.textString = subtypeButtons[index].nextItem.Description;
+        }
+
+        public static UIPartActionSubtypeSelector CreatePrefab()
+        {
+            GameObject partActionVariantSelectorPrefabGameObject = UIPartActionController.Instance.fieldPrefabs.OfType<UIPartActionVariantSelector>().FirstOrDefault()?.gameObject;
+
+            if (partActionVariantSelectorPrefabGameObject.IsNull())
+                throw new Exception("Could not find FieldVariantSelector prefab");
+
+            GameObject partActionSubtypeSelectorGameObject = Instantiate(partActionVariantSelectorPrefabGameObject);
+            DontDestroyOnLoad(partActionSubtypeSelectorGameObject);
+
+            UIPartActionVariantSelector partActionVariantSelector = partActionSubtypeSelectorGameObject.GetComponent<UIPartActionVariantSelector>();
+            UIPartActionSubtypeSelector partActionSubtypeSelector = partActionSubtypeSelectorGameObject.AddComponent<UIPartActionSubtypeSelector>();
+
+            partActionSubtypeSelector.buttonPrevious = partActionVariantSelector.buttonPrevious;
+            partActionSubtypeSelector.buttonNext = partActionVariantSelector.buttonNext;
+            partActionSubtypeSelector.scrollMain = partActionVariantSelector.scrollMain;
+            partActionSubtypeSelector.subtypeTitleText = partActionVariantSelector.variantName;
+            partActionSubtypeSelector.buttonPreviousTooltipController = partActionSubtypeSelector.buttonPrevious.gameObject.AddComponent<TooltipController_TitleAndText>();
+            partActionSubtypeSelector.buttonNextTooltipController = partActionSubtypeSelector.buttonNext.gameObject.AddComponent<TooltipController_TitleAndText>();
+
+            partActionSubtypeSelector.switcherDescriptionText = partActionSubtypeSelectorGameObject.GetChild("Label_Variants").GetComponent<TMPro.TextMeshProUGUI>();
+
+            partActionSubtypeSelector.subtypeTitleText.alignment = TMPro.TextAlignmentOptions.Right;
+
+            RectTransform switcherDescriptionRectTransform = (RectTransform)partActionSubtypeSelector.switcherDescriptionText.gameObject.transform;
+            switcherDescriptionRectTransform.anchorMin = new Vector2(0, 1);
+            switcherDescriptionRectTransform.anchorMax = new Vector2(0, 1);
+            switcherDescriptionRectTransform.pivot = new Vector2(0, 0.5f);
+            switcherDescriptionRectTransform.anchoredPosition = new Vector2(0, -5);
+            switcherDescriptionRectTransform.sizeDelta += new Vector2(45, 0);
+
+            RectTransform subypeTitleRectTransform = (RectTransform)partActionSubtypeSelector.subtypeTitleText.gameObject.transform;
+            subypeTitleRectTransform.pivot = new Vector2(1, 0.5f);
+            subypeTitleRectTransform.anchoredPosition = new Vector2(0, -5);
+            subypeTitleRectTransform.sizeDelta -= new Vector2(20, 0);
+
+            partActionSubtypeSelector.prefabVariantButton = UIPartActionSubtypeButton.CreatePrefab(partActionVariantSelector.prefabVariantButton);
+
+            Destroy(partActionVariantSelector);
+
+            return partActionSubtypeSelector;
+        }
+    }
+}

--- a/B9PartSwitch/UI/UI_SubtypeSelector.cs
+++ b/B9PartSwitch/UI/UI_SubtypeSelector.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace B9PartSwitch.UI
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field)]
+    public class UI_SubtypeSelector : UI_Control
+    {
+    }
+}

--- a/B9PartSwitch/Utils/ColorParser.cs
+++ b/B9PartSwitch/Utils/ColorParser.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace B9PartSwitch.Utils
+{
+    public static class ColorParser
+    {
+        private static readonly Dictionary<string, Color> namedColors = new Dictionary<string, Color>();
+
+        private static readonly char[] commaSeparator = { ',' };
+        private static readonly char[] spaceSeparator = { ' ', '\t' };
+
+        static ColorParser()
+        {
+            foreach (PropertyInfo propertyInfo in typeof(Color).GetProperties(BindingFlags.Static | BindingFlags.Public))
+            {
+                if (!propertyInfo.CanRead) continue;
+                if (propertyInfo.PropertyType != typeof(Color)) continue;
+                
+                namedColors.Add(propertyInfo.Name, (Color)propertyInfo.GetValue(null, null));
+            }
+
+            foreach (PropertyInfo propertyInfo in typeof(XKCDColors).GetProperties(BindingFlags.Static | BindingFlags.Public))
+            {
+                if (!propertyInfo.CanRead) continue;
+                if (propertyInfo.PropertyType != typeof(Color)) continue;
+
+                if (namedColors.ContainsKey(propertyInfo.Name)) throw new Exception("duplicate key " + propertyInfo.Name);
+
+                namedColors.Add(propertyInfo.Name, (Color)propertyInfo.GetValue(null, null));
+            }
+        }
+
+        public static Color Parse(string colorStr)
+        {
+            colorStr.ThrowIfNullArgument(nameof(colorStr));
+            if (colorStr == string.Empty) throw new FormatException("Cannot parse empty color");
+
+            if (colorStr[0] == '#')
+            {
+                switch (colorStr.Length)
+                {
+                    case 4: // #RGB
+                        byte red1 = ParseHex(colorStr[1]);
+                        byte green1 = ParseHex(colorStr[2]);
+                        byte blue1 = ParseHex(colorStr[3]);
+                        return new Color(red1 / 15f, green1 / 15f, blue1 / 15f);
+
+                    case 5: // #RGBA
+                        byte red2 = ParseHex(colorStr[1]);
+                        byte green2 = ParseHex(colorStr[2]);
+                        byte blue2 = ParseHex(colorStr[3]);
+                        byte alpha2 = ParseHex(colorStr[4]);
+                        return new Color(red2 / 15f, green2 / 15f, blue2 / 15f, alpha2 / 15f);
+
+                    case 7: // #RRGGBB
+                        int red3 = (ParseHex(colorStr[1]) << 4) | ParseHex(colorStr[2]);
+                        int green3 = (ParseHex(colorStr[3]) << 4) | ParseHex(colorStr[4]);
+                        int blue3 = (ParseHex(colorStr[5]) << 4) | ParseHex(colorStr[6]);
+                        return new Color(red3 / 255f, green3 / 255f, blue3 / 255f);
+
+                    case 9: // #RRGGBBAA
+                        int red4 = (ParseHex(colorStr[1]) << 4) | ParseHex(colorStr[2]);
+                        int green4 = (ParseHex(colorStr[3]) << 4) | ParseHex(colorStr[4]);
+                        int blue4 = (ParseHex(colorStr[5]) << 4) | ParseHex(colorStr[6]);
+                        int alpha4 = (ParseHex(colorStr[7]) << 4) | ParseHex(colorStr[8]);
+                        return new Color(red4 / 255f, green4 / 255f, blue4 / 255f, alpha4 / 255f);
+
+                    default:
+                        throw new FormatException("Value looks like HTML color (begins with #) but has wrong number of digits (must be 3, 4, 6, or 8): " + colorStr);
+                }
+            }
+            else if (namedColors.TryGetValue(colorStr, out Color namedColor))
+            {
+                return namedColor;
+            }
+
+            string[] splits;
+
+            if (colorStr.IndexOf(',') != -1)
+            {
+                splits = colorStr.Split(commaSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+                for (int i = 0; i < splits.Length; i++)
+                {
+                    splits[i] = splits[i].Trim();
+                }
+            }
+            else
+            {
+                splits = colorStr.Split(spaceSeparator, StringSplitOptions.RemoveEmptyEntries);
+            }
+
+            if (splits.Length == 3)
+            {
+                float red = ParseFloatValue(splits[0]);
+                float green = ParseFloatValue(splits[1]);
+                float blue = ParseFloatValue(splits[2]);
+                return new Color(red, green, blue);
+            }
+            else if (splits.Length == 4)
+            {
+                float red = ParseFloatValue(splits[0]);
+                float green = ParseFloatValue(splits[1]);
+                float blue = ParseFloatValue(splits[2]);
+                float alpha = ParseFloatValue(splits[3]);
+                return new Color(red, green, blue, alpha);
+            }
+            else
+            {
+                throw new FormatException("Could not value parse as color: " + colorStr);
+            }
+        }
+
+        private static byte ParseHex(char value)
+        {
+            switch (value)
+            {
+                case '0':
+                    return 0;
+                case '1':
+                    return 1;
+                case '2':
+                    return 2;
+                case '3':
+                    return 3;
+                case '4':
+                    return 4;
+                case '5':
+                    return 5;
+                case '6':
+                    return 6;
+                case '7':
+                    return 7;
+                case '8':
+                    return 8;
+                case '9':
+                    return 9;
+                case 'A':
+                case 'a':
+                    return 10;
+                case 'B':
+                case 'b':
+                    return 11;
+                case 'C':
+                case 'c':
+                    return 12;
+                case 'D':
+                case 'd':
+                    return 13;
+                case 'E':
+                case 'e':
+                    return 14;
+                case 'F':
+                case 'f':
+                    return 15;
+                default:
+                    throw new FormatException("Invalid hexadecimal character: " + value);
+            }
+        }
+
+        private static float ParseFloatValue(string valueStr)
+        {
+            if (!float.TryParse(valueStr, out float value) || float.IsNaN(value) || value < 0 || value > 1)
+                throw new FormatException("Invalid float value when parsing color (should be 0-1): " + valueStr);
+
+            return value;
+        }
+    }
+}

--- a/B9PartSwitch/Utils/ColorParser.cs
+++ b/B9PartSwitch/Utils/ColorParser.cs
@@ -18,7 +18,7 @@ namespace B9PartSwitch.Utils
             {
                 if (!propertyInfo.CanRead) continue;
                 if (propertyInfo.PropertyType != typeof(Color)) continue;
-                
+
                 namedColors.Add(propertyInfo.Name, (Color)propertyInfo.GetValue(null, null));
             }
 
@@ -31,6 +31,16 @@ namespace B9PartSwitch.Utils
 
                 namedColors.Add(propertyInfo.Name, (Color)propertyInfo.GetValue(null, null));
             }
+
+            namedColors.Add("ResourceColorLiquidFuel", ResourceColors.LiquidFuel);
+            namedColors.Add("ResourceColorLqdHydrogen", ResourceColors.LqdHydrogen);
+            namedColors.Add("ResourceColorLqdMethane", ResourceColors.LqdMethane);
+            namedColors.Add("ResourceColorOxidizer", ResourceColors.Oxidizer);
+            namedColors.Add("ResourceColorMonoPropellant", ResourceColors.MonoPropellant);
+            namedColors.Add("ResourceColorXenonGas", ResourceColors.XenonGas);
+            namedColors.Add("ResourceColorElectricChargePrimary", ResourceColors.ElectricChargePrimary);
+            namedColors.Add("ResourceColorElectricChargeSecondary", ResourceColors.ElectricChargeSecondary);
+            namedColors.Add("ResourceColorOre", ResourceColors.Ore);
         }
 
         public static Color Parse(string colorStr)

--- a/B9PartSwitch/Utils/GroupedStringBuilder.cs
+++ b/B9PartSwitch/Utils/GroupedStringBuilder.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Text;
+
+namespace B9PartSwitch.Utils
+{
+    public class GroupedStringBuilder
+    {
+        private enum State
+        {
+            Initial,
+            TextWritten,
+            WaitingForNewline,
+            WaitingForGroup,
+        }
+
+        private readonly StringBuilder stringBuilder = new StringBuilder();
+
+        private State state = State.Initial;
+
+        public void BeginGroup()
+        {
+            if (state != State.Initial) state = State.WaitingForGroup;
+        }
+
+        public void Append(string value)
+        {
+            CheckState();
+            stringBuilder.Append(value);
+            state = State.TextWritten;
+        }
+
+        public void Append(string value, object arg0)
+        {
+            CheckState();
+            stringBuilder.AppendFormat(value, arg0);
+            state = State.TextWritten;
+        }
+
+        public void Append(string format, object arg0, object arg1)
+        {
+            CheckState();
+            stringBuilder.AppendFormat(format, arg0, arg1);
+            state = State.TextWritten;
+        }
+
+        public void Append(string format, object arg0, object arg1, object arg2)
+        {
+            CheckState();
+            stringBuilder.AppendFormat(format, arg0, arg1, arg2);
+            state = State.TextWritten;
+        }
+
+        public void AppendLine()
+        {
+            CheckState();
+            state = State.WaitingForNewline;
+        }
+
+        public void AppendLine(string value)
+        {
+            CheckState();
+            stringBuilder.AppendFormat(value);
+            state = State.WaitingForNewline;
+        }
+
+        public void AppendLine(string format, object arg0)
+        {
+            CheckState();
+            stringBuilder.AppendFormat(format, arg0);
+            state = State.WaitingForNewline;
+        }
+
+        public void AppendLine(string format, object arg0, object arg1)
+        {
+            CheckState();
+            stringBuilder.AppendFormat(format, arg0, arg1);
+            state = State.WaitingForNewline;
+        }
+
+        public override string ToString() => stringBuilder.ToString();
+
+        public void Clear()
+        {
+            stringBuilder.Length = 0;
+            state = State.Initial;
+        }
+
+        private void CheckState()
+        {
+            if (state == State.WaitingForGroup)
+                stringBuilder.Append("\n\n");
+            else if (state == State.WaitingForNewline)
+                stringBuilder.Append("\n");
+        }
+    }
+}

--- a/B9PartSwitch/Utils/ResourceColors.cs
+++ b/B9PartSwitch/Utils/ResourceColors.cs
@@ -1,0 +1,18 @@
+using System;
+using UnityEngine;
+
+namespace B9PartSwitch.Utils
+{
+    public static class ResourceColors
+    {
+        public static Color LiquidFuel = new Color(0.749f, 0.655f, 0.376f);
+        public static Color LqdHydrogen = new Color(0.6f, 0.8f, 1);
+        public static Color LqdMethane = new Color(0, 0.749f, 0.561f);
+        public static Color MonoPropellant = new Color(1, 1, 0.8f);
+        public static Color Oxidizer = new Color(0.2f, 0.6f, 0.8f);
+        public static Color XenonGas = new Color(0.376f, 0.655f, 0.749f);
+        public static Color ElectricChargePrimary = new Color(1, 1, 0.2f);
+        public static Color ElectricChargeSecondary = new Color(0.188f, 0.188f, 0.188f);
+        public static Color Ore = new Color(0.251f, 0.188f, 0.125f);
+    }
+}

--- a/B9PartSwitchTests/B9PartSwitchTests.csproj
+++ b/B9PartSwitchTests/B9PartSwitchTests.csproj
@@ -122,6 +122,7 @@
     <Compile Include="TestUtils\TestConfigNode.cs" />
     <Compile Include="TestUtils\TestConfigNodeTest.cs" />
     <Compile Include="Utils\ColorParserTest.cs" />
+    <Compile Include="Utils\GroupedStringBuilderTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/B9PartSwitchTests/B9PartSwitchTests.csproj
+++ b/B9PartSwitchTests/B9PartSwitchTests.csproj
@@ -121,6 +121,7 @@
     <Compile Include="TestUtils\DummyTypes\DummyIContextualNodeTest.cs" />
     <Compile Include="TestUtils\TestConfigNode.cs" />
     <Compile Include="TestUtils\TestConfigNodeTest.cs" />
+    <Compile Include="Utils\ColorParserTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/B9PartSwitchTests/Utils/ColorParserTest.cs
+++ b/B9PartSwitchTests/Utils/ColorParserTest.cs
@@ -160,6 +160,20 @@ namespace B9PartSwitchTests.Utils
         }
 
         [Fact]
+        public void TestParseColor__ResourceColors()
+        {
+            Assert.Equal(ResourceColors.LiquidFuel, ColorParser.Parse("ResourceColorLiquidFuel"));
+            Assert.Equal(ResourceColors.LqdHydrogen, ColorParser.Parse("ResourceColorLqdHydrogen"));
+            Assert.Equal(ResourceColors.LqdMethane, ColorParser.Parse("ResourceColorLqdMethane"));
+            Assert.Equal(ResourceColors.Oxidizer, ColorParser.Parse("ResourceColorOxidizer"));
+            Assert.Equal(ResourceColors.MonoPropellant, ColorParser.Parse("ResourceColorMonoPropellant"));
+            Assert.Equal(ResourceColors.XenonGas, ColorParser.Parse("ResourceColorXenonGas"));
+            Assert.Equal(ResourceColors.ElectricChargePrimary, ColorParser.Parse("ResourceColorElectricChargePrimary"));
+            Assert.Equal(ResourceColors.ElectricChargeSecondary, ColorParser.Parse("ResourceColorElectricChargeSecondary"));
+            Assert.Equal(ResourceColors.Ore, ColorParser.Parse("ResourceColorOre"));
+        }
+
+        [Fact]
         public void TestParseColor__FloatList__RGB()
         {
             Color color = ColorParser.Parse("0, 0.5, 1");

--- a/B9PartSwitchTests/Utils/ColorParserTest.cs
+++ b/B9PartSwitchTests/Utils/ColorParserTest.cs
@@ -1,0 +1,294 @@
+﻿using System;
+using Xunit;
+using UnityEngine;
+using B9PartSwitch.Utils;
+
+namespace B9PartSwitchTests.Utils
+{
+    public class ColorParserTest
+    {
+        [Fact]
+        public void TestParseColor__Null()
+        {
+            Assert.Throws<ArgumentNullException>(delegate
+            {
+                ColorParser.Parse(null);
+            });
+        }
+
+        [Fact]
+        public void TestParseColor__Empty()
+        {
+            Assert.Throws<FormatException>(delegate
+            {
+                ColorParser.Parse("");
+            });
+        }
+
+        [Fact]
+        public void TestParseColor__HexStr__RGB()
+        {
+            Color color = ColorParser.Parse("#07f");
+
+            Assert.Equal(0, color.r);
+            Assert.Equal(0x7 / 15f, color.g);
+            Assert.Equal(1, color.b);
+            Assert.Equal(1, color.a);
+        }
+
+        [Fact]
+        public void TestParseColor__HexStr__RGBA()
+        {
+            Color color = ColorParser.Parse("#fa50");
+
+            Assert.Equal(1, color.r);
+            Assert.Equal(0xa / 15f, color.g);
+            Assert.Equal(0x5 / 15f, color.b);
+            Assert.Equal(0, color.a);
+        }
+
+        [Fact]
+        public void TestParseColor__HexStr__RRGGBB()
+        {
+            Color color = ColorParser.Parse("#002fff");
+
+            Assert.Equal(0, color.r);
+            Assert.Equal(0x2f / 255f, color.g);
+            Assert.Equal(1, color.b);
+            Assert.Equal(1, color.a);
+        }
+
+        [Fact]
+        public void TestParseColor__HexStr__RRGGBBAA()
+        {
+            Color color = ColorParser.Parse("#ffab5600");
+
+            Assert.Equal(1, color.r);
+            Assert.Equal(0xab / 255f, color.g);
+            Assert.Equal(0x56 / 255f, color.b);
+            Assert.Equal(0, color.a);
+        }
+
+        [Fact]
+        public void TestParseColor__HexStr__Upper()
+        {
+            Color color = ColorParser.Parse("#0AF");
+
+            Assert.Equal(0, color.r);
+            Assert.Equal(0xa / 15f, color.g);
+            Assert.Equal(1, color.b);
+            Assert.Equal(1, color.a);
+        }
+
+        [Fact]
+        public void TestParseColor__HexStr__InvalidHex()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                ColorParser.Parse("#00g");
+            });
+
+            Assert.Equal("Invalid hexadecimal character: g", ex.Message);
+        }
+
+        [Fact]
+        public void TestParseColor__HexStr__TooShort()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                ColorParser.Parse("#ab");
+            });
+
+            Assert.Equal("Value looks like HTML color (begins with #) but has wrong number of digits (must be 3, 4, 6, or 8): #ab", ex.Message);
+        }
+
+        [Fact]
+        public void TestParseColor__HexStr__FiveDigits()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                ColorParser.Parse("#abcde");
+            });
+
+            Assert.Equal("Value looks like HTML color (begins with #) but has wrong number of digits (must be 3, 4, 6, or 8): #abcde", ex.Message);
+        }
+
+        [Fact]
+        public void TestParseColor__HexStr__TooLong()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                ColorParser.Parse("#012345678");
+            });
+
+            Assert.Equal("Value looks like HTML color (begins with #) but has wrong number of digits (must be 3, 4, 6, or 8): #012345678", ex.Message);
+        }
+
+        [Fact]
+        public void TestParseColor__NamedColor__red()
+        {
+            Color color = ColorParser.Parse("red");
+            Assert.Equal(Color.red, color);
+        }
+
+        [Fact]
+        public void TestParseColor__NamedColor__magenta()
+        {
+            Color color = ColorParser.Parse("magenta");
+            Assert.Equal(Color.magenta, color);
+        }
+
+        [Fact]
+        public void TestParseColor__NamedColor__xkcd__Red()
+        {
+            Color color = ColorParser.Parse("Red");
+            Assert.Equal(XKCDColors.Red, color);
+        }
+
+        [Fact]
+        public void TestParseColor__NamedColor__xkcd__Goldenrod()
+        {
+            Color color = ColorParser.Parse("Goldenrod");
+            Assert.Equal(XKCDColors.Goldenrod, color);
+        }
+
+        [Fact]
+        public void TestParseColor__NamedColor__xkcd__GoldenRod()
+        {
+            Color color = ColorParser.Parse("GoldenRod");
+            Assert.Equal(XKCDColors.GoldenRod, color);
+        }
+
+        [Fact]
+        public void TestParseColor__FloatList__RGB()
+        {
+            Color color = ColorParser.Parse("0, 0.5, 1");
+
+            Assert.Equal(0, color.r);
+            Assert.Equal(0.5f, color.g);
+            Assert.Equal(1, color.b);
+            Assert.Equal(1, color.a);
+        }
+
+        [Fact]
+        public void TestParseColor__FloatList__RGBA()
+        {
+            Color color = ColorParser.Parse("1, 0.7, 0.3, 0");
+
+            Assert.Equal(1, color.r);
+            Assert.Equal(0.7f, color.g);
+            Assert.Equal(0.3f, color.b);
+            Assert.Equal(0, color.a);
+        }
+
+        [Fact]
+        public void TestParseColor__FloatList__CommaSeparatedWithNoSpaces()
+        {
+            Color color = ColorParser.Parse("0,0.5,1");
+
+            Assert.Equal(0, color.r);
+            Assert.Equal(0.5f, color.g);
+            Assert.Equal(1, color.b);
+            Assert.Equal(1, color.a);
+        }
+
+        [Fact]
+        public void TestParseColor__FloatList__SpaceSeparated()
+        {
+            Color color = ColorParser.Parse("0 0.5 1");
+
+            Assert.Equal(0, color.r);
+            Assert.Equal(0.5f, color.g);
+            Assert.Equal(1, color.b);
+            Assert.Equal(1, color.a);
+        }
+
+        [Fact]
+        public void TestParseColor__FloatList__TabSeparated()
+        {
+            Color color = ColorParser.Parse("0\t0.5\t1");
+
+            Assert.Equal(0, color.r);
+            Assert.Equal(0.5f, color.g);
+            Assert.Equal(1, color.b);
+            Assert.Equal(1, color.a);
+        }
+
+        [Fact]
+        public void TestParseColor__FloatList__TooShort()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                ColorParser.Parse("0, 1");
+            });
+
+            Assert.Equal("Could not value parse as color: 0, 1", ex.Message);
+        }
+
+        [Fact]
+        public void TestParseColor__FloatList__TooLong()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                ColorParser.Parse("0, 1, 2, 3, 4");
+            });
+
+            Assert.Equal("Could not value parse as color: 0, 1, 2, 3, 4", ex.Message);
+        }
+
+        [Fact]
+        public void TestParseColor__FloatList__InvalidFloat()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                ColorParser.Parse("0, x, 1");
+            });
+
+            Assert.Equal("Invalid float value when parsing color (should be 0-1): x", ex.Message);
+        }
+
+        [Fact]
+        public void TestParseColor__FloatList__NaN()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                ColorParser.Parse("0, NaN, 1");
+            });
+
+            Assert.Equal("Invalid float value when parsing color (should be 0-1): NaN", ex.Message);
+        }
+
+        [Fact]
+        public void TestParseColor__FloatList__TooSmall()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                ColorParser.Parse("0, -0.1, 1");
+            });
+
+            Assert.Equal("Invalid float value when parsing color (should be 0-1): -0.1", ex.Message);
+        }
+
+        [Fact]
+        public void TestParseColor__FloatList__TooLarge()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                ColorParser.Parse("0, 1.1, 1");
+            });
+
+            Assert.Equal("Invalid float value when parsing color (should be 0-1): 1.1", ex.Message);
+        }
+
+        [Fact]
+        public void TestParseColor__UnknownFormat()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                ColorParser.Parse("stuff");
+            });
+
+            Assert.Equal("Could not value parse as color: stuff", ex.Message);
+        }
+    }
+}

--- a/B9PartSwitchTests/Utils/GroupedStringBuilderTest.cs
+++ b/B9PartSwitchTests/Utils/GroupedStringBuilderTest.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Xunit;
+using B9PartSwitch.Utils;
+
+namespace B9PartSwitchTests.Utils
+{
+    public class GroupedStringBuilderTest
+    {
+        private readonly GroupedStringBuilder stringBuilder = new GroupedStringBuilder();
+        [Fact]
+        public void TestBeginGroup()
+        {
+            stringBuilder.BeginGroup();
+            stringBuilder.Append("abc");
+            stringBuilder.BeginGroup();
+            stringBuilder.AppendLine("def");
+            stringBuilder.AppendLine("ghi");
+            stringBuilder.BeginGroup();
+            stringBuilder.BeginGroup();
+            stringBuilder.AppendLine("jkl");
+            stringBuilder.BeginGroup();
+
+            Assert.Equal("abc\n\ndef\nghi\n\njkl", stringBuilder.ToString());
+        }
+
+        [Fact]
+        public void TestAppend()
+        {
+            stringBuilder.Append("a");
+            stringBuilder.Append("b {0:0.0} c", 1);
+            stringBuilder.Append("d {0:0.0} e {1:0.0} f", 1, 2);
+            stringBuilder.Append("g {0:0.0} h {1:0.0} i {2:0.0} j", 1, 2, 3);
+
+            Assert.Equal("ab 1.0 cd 1.0 e 2.0 fg 1.0 h 2.0 i 3.0 j", stringBuilder.ToString());
+        }
+
+        [Fact]
+        public void TestAppendLine()
+        {
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("a");
+            stringBuilder.Append("b");
+            stringBuilder.AppendLine("c {0:0.0} d", 1);
+            stringBuilder.AppendLine("e {0:0.0} f {1:0.0} g", 1, 2);
+
+            Assert.Equal("\na\nbc 1.0 d\ne 1.0 f 2.0 g", stringBuilder.ToString());
+        }
+
+        [Fact]
+        public void TestClear()
+        {
+            stringBuilder.Append("abc");
+            stringBuilder.BeginGroup();
+            Assert.Equal("abc", stringBuilder.ToString());
+            stringBuilder.Clear();
+            stringBuilder.Append("def");
+            Assert.Equal("def", stringBuilder.ToString());
+        }
+    }
+}

--- a/GameData/B9PartSwitch/DefaultTankTypes.cfg
+++ b/GameData/B9PartSwitch/DefaultTankTypes.cfg
@@ -12,6 +12,7 @@ B9_TANK_TYPE
 	title = #LOC_B9PartSwitch_tank_type_lf // LiquidFuel
 	tankMass = 0.0001
 	tankCost = 0.375
+
 	RESOURCE
 	{
 		name = LiquidFuel

--- a/GameData/B9PartSwitch/Localization/en-us.cfg
+++ b/GameData/B9PartSwitch/Localization/en-us.cfg
@@ -15,5 +15,10 @@ Localization
         #LOC_B9PartSwitch_tank_type_lfo = LFO
         #LOC_B9PartSwitch_tank_type_monoprop = MonoPropellant
         #LOC_B9PartSwitch_tank_type_ec = Battery
+        #LOC_B9PartSwitch_SwitcherSubtypeDescriptionGenerator_max_temp = Maximum Temperature
+        #LOC_B9PartSwitch_SwitcherSubtypeDescriptionGenerator_max_skin_temp = Maximum Skin Temperature
+        #LOC_B9PartSwitch_SwitcherSubtypeDescriptionGenerator_crash_tolerance = Crash Tolerance
+        #LOC_B9PartSwitch_SwitcherSubtypeDescriptionGenerator_tank_empty = empty
+        #LOC_B9PartSwitch_SwitcherSubtypeDescriptionGenerator_tank_full = full
     }
 }


### PR DESCRIPTION
* Implement new switching UI based on the stock variant switcher
* Have subtype switching buttons show some info about the subtype being switched to in a tooltip
  * By default shows resources (including parent), mass, cost, max temperature, max skin temperature, crash tolerance
  * Also shows `descriptionSummary` and `descriptionDetail` from subtype, before and after auto-generated info respectively, if present
* 4 new fieds on `SUBTYPE`
  * `descriptionSummary` - any info here will be put in the subtype switching tooltip before the auto-generated info - make it brief
  * `descriptionDetail` - any info here will be put in the subtype switching tooltip after the auto-generated info - go nuts
  * `primaryColor` - color to use in the left part of the switching button
    * if not specified, use the tank type's primaryColor
    * if that's not specified, use white
  * `secondaryColor` - color to use in the right part of the switching button
    * if not specified, use the tank's secondaryColor
    * if that's not specified, use the subtype's primaryColor
    * if that's not specified, use the tank's primaryColor
    * if that's not specified, use gray
* 2 new fields on `B9_TANK_TYPE`
  * `primaryColor` - color to use in the left part of the switching button i they subtype does not specify one.  If not specified, common resource combinations will be used.
  * `secondaryColor` - color to use in the right part of the switching button i they subtype does not specify one.  If not specified, common resource combinations will be used.
* add default colors for common resources
  * `ResourceColorLiquidFuel`
  * `ResourceColorLqdHydrogen`
  * `ResourceColorLqdMethane`
  * `ResourceColorOxidizer`
  * `ResourceColorMonoPropellant`
  * `ResourceColorXenonGas`
  * `ResourceColorElectricChargePrimary`
  * `ResourceColorElectricChareSecondary`
  * `ResourceColorOre`
* Automatically apply resource colors to common resource combinations in tanks (if colors are not specified by the tank or subtype):
  * LiquidFuel
  * LiquidFuel/Oxidizer
  * LqdHydrogen
  * LqdHydrogen/Oxidizer
  * LqdMethane
  * LqdMethane/Oxidizer
  * Oxidizer
  * MonoPropellant
  * XenonGas
  * Ore
  * ElectricCharge