### PR TITLE
Allow switching ui to not be moved to bottom of PAW

### DIFF
--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -50,6 +50,9 @@ namespace B9PartSwitch
         [NodeData]
         public bool advancedTweakablesOnly = false;
 
+        [NodeData]
+        public bool bottomOfWindow = true;
+
         [NodeData(name = "currentSubtype", persistent = true)]
         public string CurrentSubtypeName
         {

--- a/B9PartSwitch/UI/UIPartActionSubtypeSelector.cs
+++ b/B9PartSwitch/UI/UIPartActionSubtypeSelector.cs
@@ -39,6 +39,8 @@ namespace B9PartSwitch.UI
 
         private List<UIPartActionSubtypeButton> subtypeButtons;
 
+        private bool bottomOfWindow;
+
         public static void EnsurePrefab()
         {
             if (UIPartActionController.Instance.IsNull()) throw new InvalidOperationException("UIPartActionController.Instance is null");
@@ -103,11 +105,13 @@ namespace B9PartSwitch.UI
             subtypeTitleText.text = switcherModule.CurrentSubtype.title;
 
             subtypeButtons[switcherModule.currentSubtypeIndex].Activate();
+
+            bottomOfWindow = switcherModule.bottomOfWindow;
         }
 
         public override void UpdateItem()
         {
-            transform.SetAsLastSibling();
+            if (bottomOfWindow) transform.SetAsLastSibling();
         }
 
         private void PreviousSubtype()


### PR DESCRIPTION
if module has `bottomOfWindow = false`, do not move it to the bottom of the PAW

Resolves #158