### PR TITLE
Allow transforms to be scaled

### DIFF
--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Fishbones\Parsers\NodeObjectWrapperIContextualNode.cs" />
     <Compile Include="Fishbones\Parsers\OverrideValueParseMap.cs" />
     <Compile Include="Fishbones\Parsers\PartResourceDefinitionValueParser.cs" />
+    <Compile Include="Fishbones\Parsers\ScaleParser.cs" />
     <Compile Include="Fishbones\Parsers\ValueParseMap.cs" />
     <Compile Include="Fishbones\Parsers\ValueParseMapWrapper.cs" />
     <Compile Include="Fishbones\Parsers\ValueParser.cs" />
@@ -135,6 +136,7 @@
     <Compile Include="PartSwitch\PartModifiers\TextureReplacement.cs" />
     <Compile Include="PartSwitch\PartModifiers\TransformMover.cs" />
     <Compile Include="PartSwitch\PartModifiers\TransformRotator.cs" />
+    <Compile Include="PartSwitch\PartModifiers\TransformScaleModifier.cs" />
     <Compile Include="PartSwitch\PartModifiers\TransformToggler.cs" />
     <Compile Include="PartSwitch\PartSubtype.cs" />
     <Compile Include="PartSwitch\PartSwitchFlightDialog.cs" />

--- a/B9PartSwitch/Fishbones/Parsers/ScaleParser.cs
+++ b/B9PartSwitch/Fishbones/Parsers/ScaleParser.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using UnityEngine;
+
+namespace B9PartSwitch.Fishbones.Parsers
+{
+    public class ScaleParser : ValueParser<Vector3>
+    {
+        private static readonly char[] splitChars = { ',', '\t', ' ' };
+
+        public static Vector3 ParseScale(string value)
+        {
+            value.ThrowIfNullArgument(nameof(value));
+
+            string[] splits = value.Split(splitChars, StringSplitOptions.RemoveEmptyEntries);
+
+            if (splits.Length == 1)
+            {
+                float scale = float.Parse(splits[0]);
+                return new Vector3(scale, scale, scale);
+            }
+            else if (splits.Length == 3)
+            {
+                float x = float.Parse(splits[0]);
+                float y = float.Parse(splits[1]);
+                float z = float.Parse(splits[2]);
+                return new Vector3(x, y, z);
+            }
+            else
+            {
+                throw new FormatException($"Could not parse value as scale because it split into {splits.Length} values: '{value}'");
+            }
+        }
+
+        public ScaleParser() : base(ParseScale, ConfigNode.WriteVector) { }
+    }
+}

--- a/B9PartSwitch/PartSwitch/PartModifiers/TransformScaleModifier.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TransformScaleModifier.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using UnityEngine;
+
+namespace B9PartSwitch.PartSwitch.PartModifiers
+{
+    public class TransformScaleModifier : PartModifierBase
+    {
+        private readonly Transform transform;
+        private readonly Vector3 scale;
+        private bool isActive = false;
+
+        public TransformScaleModifier(Transform transform, Vector3 scale)
+        {
+            transform.ThrowIfNullArgument(nameof(transform));
+
+            this.transform = transform;
+            this.scale = scale;
+        }
+
+        public override string Description => $"transform '{transform.name}' relative scale";
+
+        public override void ActivateOnStartEditor() => Activate();
+        public override void ActivateOnStartFlight() => Activate();
+        public override void ActivateOnSwitchEditor() => Activate();
+        public override void ActivateOnSwitchFlight() => Activate();
+        public override void DeactivateOnSwitchEditor() => Deactivate();
+        public override void DeactivateOnSwitchFlight() => Deactivate();
+        public override void OnIconCreateActiveSubtype() => Activate();
+        public override void OnWillBeCopiedActiveSubtype() => Deactivate();
+        public override void OnWasCopiedActiveSubtype() => Activate();
+        public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
+
+        private void Activate()
+        {
+            if (isActive) return;
+
+            Vector3 localScale = transform.localScale;
+            localScale.Scale(scale);
+            transform.localScale = localScale;
+            isActive = true;
+        }
+
+        private void Deactivate()
+        {
+            if (!isActive) return;
+
+            Vector3 localScale = transform.localScale;
+            localScale.x /= scale.x;
+            localScale.y /= scale.y;
+            localScale.z /= scale.z;
+            transform.localScale = localScale;
+            isActive = false;
+        }
+    }
+}

--- a/B9PartSwitch/PartSwitch/TransformModifierInfo.cs
+++ b/B9PartSwitch/PartSwitch/TransformModifierInfo.cs
@@ -18,6 +18,10 @@ namespace B9PartSwitch
         [NodeData]
         public Vector3? rotationOffset;
 
+        [NodeData]
+        [UseParser(typeof(Fishbones.Parsers.ScaleParser))]
+        public Vector3? scaleOffset;
+
         public void Load(ConfigNode node, OperationContext context) => this.LoadFields(node, context);
         public void Save(ConfigNode node, OperationContext context) => this.SaveFields(node, context);
 
@@ -45,6 +49,10 @@ namespace B9PartSwitch
                 if (rotationOffset.HasValue)
                 {
                     yield return new TransformRotator(transform, Quaternion.Euler(rotationOffset.Value));
+                }
+                if (scaleOffset.HasValue)
+                {
+                    yield return new TransformScaleModifier(transform, scaleOffset.Value);
                 }
             }
 

--- a/B9PartSwitchTests/B9PartSwitchTests.csproj
+++ b/B9PartSwitchTests/B9PartSwitchTests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Fishbones\Parsers\NodeObjectWrapperIContextualNodeTest.cs" />
     <Compile Include="Fishbones\Parsers\NodeObjectWrapperTest.cs" />
     <Compile Include="Fishbones\Parsers\OverrideValueParseMapTest.cs" />
+    <Compile Include="Fishbones\Parsers\ScaleParserTest.cs" />
     <Compile Include="Fishbones\Parsers\ValueParseMapTest.cs" />
     <Compile Include="Fishbones\Parsers\ValueParseMapWrapperTest.cs" />
     <Compile Include="Fishbones\Parsers\ValueParserTest.cs" />

--- a/B9PartSwitchTests/Fishbones/Parsers/OverrideValueParseMapTest.cs
+++ b/B9PartSwitchTests/Fishbones/Parsers/OverrideValueParseMapTest.cs
@@ -13,10 +13,12 @@ namespace B9PartSwitchTests.Fishbones.Parsers
         private class DummyClass2 { }
         private class DummyClass3 { }
         private class DummyClass4 { }
+        private struct DummyStruct { }
 
-        private IValueParseMap innerParseMap = Substitute.For<IValueParseMap>();
-        private IValueParser parser1 = Substitute.For<IValueParser>();
-        private IValueParser parser2 = Substitute.For<IValueParser>();
+        private readonly IValueParseMap innerParseMap = Substitute.For<IValueParseMap>();
+        private readonly IValueParser parser1 = Substitute.For<IValueParser>();
+        private readonly IValueParser parser2 = Substitute.For<IValueParser>();
+        private readonly IValueParser parserStruct = Substitute.For<IValueParser>();
 
         private OverrideValueParseMap parseMap;
 
@@ -24,8 +26,9 @@ namespace B9PartSwitchTests.Fishbones.Parsers
         {
             parser1.ParseType.Returns(typeof(DummyClass1));
             parser2.ParseType.Returns(typeof(DummyClass2));
+            parserStruct.ParseType.Returns(typeof(DummyStruct));
 
-            parseMap = new OverrideValueParseMap(innerParseMap, parser1, parser2);
+            parseMap = new OverrideValueParseMap(innerParseMap, parser1, parser2, parserStruct);
         }
 
         #region Constructor
@@ -75,6 +78,15 @@ namespace B9PartSwitchTests.Fishbones.Parsers
         }
 
         [Fact]
+        public void TestCanParse__Override__Nullable()
+        {
+            innerParseMap.CanParse(typeof(DummyStruct)).Returns(false);
+
+            Assert.True(parseMap.CanParse(typeof(DummyStruct)));
+            Assert.True(parseMap.CanParse(typeof(DummyStruct?)));
+        }
+
+        [Fact]
         public void TestCanParse__NullArgument()
         {
             Assert.Throws<ArgumentNullException>(() => parseMap.CanParse(null));
@@ -109,6 +121,26 @@ namespace B9PartSwitchTests.Fishbones.Parsers
             innerParseMap.CanParse(typeof(DummyClass2)).Returns(true);
 
             Assert.Same(parser2, parseMap.GetParser(typeof(DummyClass2)));
+
+            innerParseMap.DidNotReceiveWithAnyArgs().GetParser(null);
+        }
+
+        [Fact]
+        public void TestGetParser__Override__Nullable__InnerMapCantParese()
+        {
+            innerParseMap.CanParse(typeof(DummyStruct)).Returns(false);
+
+            Assert.Same(parserStruct, parseMap.GetParser(typeof(DummyStruct?)));
+
+            innerParseMap.DidNotReceiveWithAnyArgs().GetParser(null);
+        }
+
+        [Fact]
+        public void TestGetParser__Override__Nullable__InnerMapCanParse()
+        {
+            innerParseMap.CanParse(typeof(DummyStruct)).Returns(true);
+
+            Assert.Same(parserStruct, parseMap.GetParser(typeof(DummyStruct?)));
 
             innerParseMap.DidNotReceiveWithAnyArgs().GetParser(null);
         }

--- a/B9PartSwitchTests/Fishbones/Parsers/ScaleParserTest.cs
+++ b/B9PartSwitchTests/Fishbones/Parsers/ScaleParserTest.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Xunit;
+using UnityEngine;
+using B9PartSwitch.Fishbones.Parsers;
+
+namespace B9PartSwitchTests.Fishbones.Parsers
+{
+    public class ScaleParserTest
+    {
+        private readonly ScaleParser parser = new ScaleParser();
+
+        [Fact]
+        public void TestParse__Single()
+        {
+            Assert.Equal(new Vector3(1.23f, 1.23f, 1.23f), parser.Parse("1.23"));
+        }
+
+        [Fact]
+        public void TestParse__Vector__Space()
+        {
+            Assert.Equal(new Vector3(1.23f, 2.34f, 3.45f), parser.Parse("1.23 2.34  3.45"));
+        }
+
+        [Fact]
+        public void TestParse__Vector__Tab()
+        {
+            Assert.Equal(new Vector3(1.23f, 2.34f, 3.45f), parser.Parse("1.23\t2.34\t\t3.45"));
+        }
+
+        [Fact]
+        public void TestParse__Vector__Comma()
+        {
+            Assert.Equal(new Vector3(1.23f, 2.34f, 3.45f), parser.Parse("1.23,2.34, 3.45"));
+        }
+
+        [Fact]
+        public void TestParse__ValueNull()
+        {
+            Assert.Throws<ArgumentNullException>(delegate
+            {
+                parser.Parse(null);
+            });
+        }
+
+        [Fact]
+        public void TestParse__Emptyish()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                parser.Parse(", ");
+            });
+
+            Assert.Equal("Could not parse value as scale because it split into 0 values: ', '", ex.Message);
+        }
+
+        [Fact]
+        public void TestParse__TwoValues()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                parser.Parse("1.23, 3.45");
+            });
+
+            Assert.Equal("Could not parse value as scale because it split into 2 values: '1.23, 3.45'", ex.Message);
+        }
+
+        [Fact]
+        public void TestParse__FourValues()
+        {
+            FormatException ex = Assert.Throws<FormatException>(delegate
+            {
+                parser.Parse("1.23, 2.34, 3.45, 4.56");
+            });
+
+            Assert.Equal("Could not parse value as scale because it split into 4 values: '1.23, 2.34, 3.45, 4.56'", ex.Message);
+        }
+
+        [Fact]
+        public void TestParse__NotAFloat()
+        {
+            Assert.Throws<FormatException>(delegate
+            {
+                parser.Parse("1.23, aaaaaa, 3.45");
+            });
+        }
+    }
+}


### PR DESCRIPTION
`TRANSFORM {}` nodes now accept a `scaleOffset` value which is the relative local scale of the model (multiplicative on each axis).  It can either be a single number which is applied to all 3 axes or a 3 numbers applied to x, y, z and separated by spaces, tabs, or commas

Resolves #145