### PR TITLE
Attach node offsets respect part rotation

### DIFF
--- a/B9PartSwitch/PartSwitch/PartModifiers/AttachNodeMover.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/AttachNodeMover.cs
@@ -41,6 +41,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
             if (!HighLogic.LoadedSceneIsEditor) return;
             if (attachNode.owner.parent != null && attachNode.owner.parent == attachNode.attachedPart)
             {
+                offset = attachNode.owner.transform.localRotation * offset;
                 attachNode.owner.transform.localPosition -= offset;
             }
             else if (attachNode.attachedPart != null)
@@ -57,6 +58,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
             if (!HighLogic.LoadedSceneIsEditor) return;
             if (attachNode.owner.parent != null && attachNode.owner.parent == attachNode.attachedPart)
             {
+                offset = attachNode.owner.transform.localRotation * offset;
                 attachNode.owner.transform.localPosition -= offset;
             }
             else if (attachNode.attachedPart != null)


### PR DESCRIPTION
When a part moves itself due to a node offset, that wasn't respecting the part's rotation

Fixes #160