### PR TITLE
texture modifiers only keep track of renderer, not material

### DIFF
--- a/B9PartSwitch/PartSwitch/PartModifiers/TextureReplacement.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TextureReplacement.cs
@@ -6,7 +6,6 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
     public class TextureReplacement : PartModifierBase
     {
         private readonly Renderer renderer;
-        private Material material;
         private readonly string shaderProperty;
         private readonly Texture oldTexture;
         private readonly Texture newTexture;
@@ -21,17 +20,14 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
             this.shaderProperty = shaderProperty;
             this.newTexture = newTexture;
 
-            // Instantiate material here rather than using sharedMaterial (which might be used by many things)
-            // Tried sharing a material across all renderers that used it here, but it lead to weirdness
-            material = renderer.material;
-            oldTexture = material.GetTexture(shaderProperty);
+            oldTexture = renderer.sharedMaterial.GetTexture(shaderProperty);
 
             if (oldTexture == null)
-                throw new ArgumentException($"{material.name} has no texture on the property {shaderProperty}");
+                throw new ArgumentException($"{renderer.sharedMaterial.name} has no texture on the property {shaderProperty}");
         }
 
-        public override object PartAspectLock => material.GetInstanceID() + "---" + shaderProperty;
-        public override string Description => $"material {material.name} property {shaderProperty}";
+        public override object PartAspectLock => renderer.GetInstanceID() + "---" + shaderProperty;
+        public override string Description => $"object {renderer.name} shader property {shaderProperty}";
 
         public override void ActivateOnStartEditor() => Activate();
         public override void ActivateOnStartFlight() => Activate();
@@ -46,13 +42,12 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
             // At this point, the copy hasn't been initialized yet, so it still shares a material with this
             // So make a copy of the material and assign it to avoid affecting the copy too
             renderer.material = new Material(renderer.material);
-            material = renderer.material;
             Activate();
         }
 
         public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
 
-        private void Activate() => material.SetTexture(shaderProperty, newTexture);
-        private void Deactivate() => material.SetTexture(shaderProperty, oldTexture);
+        private void Activate() => renderer.material.SetTexture(shaderProperty, newTexture);
+        private void Deactivate() => renderer.material.SetTexture(shaderProperty, oldTexture);
     }
 }


### PR DESCRIPTION
it'll be instantiated when it needs to be

right now after a part is copied, the active subtype is re-instantiating the material, but other subtypes are still referencing the old material which will be unused at that point

so instead we just call renderer.material every time, which will instantiate when necessary

Resolves #174