### PR TITLE
Support other modules updating the part's model

### DIFF
--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Fishbones\OperationManager.cs" />
     <Compile Include="Fishbones\UseParser.cs" />
     <Compile Include="Localization.cs" />
+    <Compile Include="Utils\ChangeTransactionManager.cs" />
     <Compile Include="ModuleB9DisableTransform.cs" />
     <Compile Include="ModuleB9PropagateCopyEvents.cs" />
     <Compile Include="PartSwitch\AttachNodeModifierInfo.cs" />

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -112,11 +112,10 @@ namespace B9PartSwitch
 
         public PartSubtype this[int index] => subtypes[index];
 
-        public IEnumerable<Transform> ManagedTransforms => subtypes.SelectMany(subtype => subtype.Transforms);
         public IEnumerable<AttachNode> ManagedNodes => subtypes.SelectMany(subtype => subtype.Nodes);
         public IEnumerable<string> ManagedResourceNames => subtypes.SelectMany(subtype => subtype.ResourceNames);
 
-        public bool ManagesTransforms => ManagedTransforms.Any();
+        public bool ChangesGeometry => subtypes.Any(subtype => subtype.ChangesGeometry);
         public bool ManagesNodes => ManagedNodes.Any();
         public bool ManagesResources => subtypes.Any(s => !s.tankType.IsStructuralTankType);
 
@@ -652,7 +651,7 @@ namespace B9PartSwitch
 
         private void UpdateGeometry(bool start)
         {
-            if (!ManagesTransforms) return;
+            if (!ChangesGeometry) return;
 
             if (FARWrapper.FARLoaded && affectFARVoxels)
             {
@@ -681,7 +680,7 @@ namespace B9PartSwitch
 
         private bool IsLastModuleAffectingDragCubes()
         {
-            ModuleB9PartSwitch lastModule = part.Modules.OfType<ModuleB9PartSwitch>().Where(m => m.ManagesTransforms && m.affectDragCubes).LastOrDefault();
+            ModuleB9PartSwitch lastModule = part.Modules.OfType<ModuleB9PartSwitch>().Where(m => m.ChangesGeometry && m.affectDragCubes).LastOrDefault();
             return ReferenceEquals(this, lastModule);
         }
 

--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -110,13 +110,9 @@ namespace B9PartSwitch
         public float VolumeFromChildren { get; private set; } = 0f;
         public float VolumeAddedToParent => CurrentSubtype.volumeAddedToParent;
 
-        public PartSubtype this[int index] => subtypes[index];
-
-        public IEnumerable<AttachNode> ManagedNodes => subtypes.SelectMany(subtype => subtype.Nodes);
         public IEnumerable<string> ManagedResourceNames => subtypes.SelectMany(subtype => subtype.ResourceNames);
 
         public bool ChangesGeometry => subtypes.Any(subtype => subtype.ChangesGeometry);
-        public bool ManagesNodes => ManagedNodes.Any();
         public bool ManagesResources => subtypes.Any(s => !s.tankType.IsStructuralTankType);
 
         public bool ChangesDryMass => subtypes.Any(s => s.ChangesDryMass);

--- a/B9PartSwitch/PartSwitch/ModuleModifierInfo.cs
+++ b/B9PartSwitch/PartSwitch/ModuleModifierInfo.cs
@@ -82,10 +82,11 @@ namespace B9PartSwitch
         public void Load(ConfigNode node, OperationContext context) => this.LoadFields(node, context);
         public void Save(ConfigNode node, OperationContext context) => this.SaveFields(node, context);
 
-        public IEnumerable<IPartModifier> CreatePartModifiers(Part part, PartModule parentModule)
+        public IEnumerable<IPartModifier> CreatePartModifiers(Part part, PartModule parentModule, BaseEventDetails moduleDataChangedEventDetails)
         {
             part.ThrowIfNullArgument(nameof(part));
             parentModule.ThrowIfNullArgument(nameof(parentModule));
+            moduleDataChangedEventDetails.ThrowIfNullArgument(nameof(moduleDataChangedEventDetails));
 
             if (identifierNode.IsNull()) throw new Exception("module modifier must have an IDENTIFIER node");
 
@@ -111,7 +112,7 @@ namespace B9PartSwitch
                     throw new InvalidOperationException($"Cannot modify data on {module.GetType()}");
                 else if (module is ModuleEnginesFX moduleEnginesFX)
                 {
-                    yield return new ModuleDataHandlerBasic(module, originalNode, dataNode);
+                    yield return new ModuleDataHandlerBasic(module, originalNode, dataNode, moduleDataChangedEventDetails);
                     if (dataNode.GetValue("flameoutEffectName") is string flameoutEffectName)
                         yield return new EffectDeactivator(part, moduleEnginesFX.flameoutEffectName, flameoutEffectName);
                     if (dataNode.GetValue("runningEffectName") is string runningEffectName)
@@ -133,10 +134,10 @@ namespace B9PartSwitch
                     // therefore, wipe all output resources before loading new data
                     // order matters here since the output resources must be empty when new data is loaded
                     yield return new ModuleOutputResourceResetter(module);
-                    yield return new ModuleDataHandlerBasic(module, originalNode, dataNode);
+                    yield return new ModuleDataHandlerBasic(module, originalNode, dataNode, moduleDataChangedEventDetails);
                 }
                 else
-                    yield return new ModuleDataHandlerBasic(module, originalNode, dataNode);
+                    yield return new ModuleDataHandlerBasic(module, originalNode, dataNode, moduleDataChangedEventDetails);
             }
 
             if (!moduleActive)

--- a/B9PartSwitch/PartSwitch/PartModifiers/ColorPropertyModifier.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/ColorPropertyModifier.cs
@@ -45,6 +45,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         }
 
         public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
+        public override void OnAfterReinitializeActiveSubtype() => Activate();
 
         private void Activate() => renderer.material.SetColor(shaderProperty, newColor);
         private void Deactivate() => renderer.material.SetColor(shaderProperty, originalColor);

--- a/B9PartSwitch/PartSwitch/PartModifiers/FloatPropertyModifier.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/FloatPropertyModifier.cs
@@ -45,6 +45,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         }
 
         public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
+        public override void OnAfterReinitializeActiveSubtype() => Activate();
 
         private void Activate() => renderer.material.SetFloat(shaderProperty, newValue);
         private void Deactivate() => renderer.material.SetFloat(shaderProperty, originalValue);

--- a/B9PartSwitch/PartSwitch/PartModifiers/IPartModifier.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/IPartModifier.cs
@@ -28,5 +28,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         void OnWasCopiedInactiveSubtype();
         void OnBeforeReinitializeInactiveSubtype();
         void OnBeforeReinitializeActiveSubtype();
+        void OnAfterReinitializeInactiveSubtype();
+        void OnAfterReinitializeActiveSubtype();
     }
 }

--- a/B9PartSwitch/PartSwitch/PartModifiers/IPartModifier.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/IPartModifier.cs
@@ -5,6 +5,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
     public interface IPartModifier
     {
         string Description { get; }
+        bool ChangesGeometry { get; }
 
         void DeactivateOnStartEditor();
         void DeactivateOnStartFlight();

--- a/B9PartSwitch/PartSwitch/PartModifiers/ModuleDataHandlerBasic.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/ModuleDataHandlerBasic.cs
@@ -30,7 +30,16 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         public override void OnWillBeCopiedActiveSubtype() => Deactivate();
         public override void OnWasCopiedActiveSubtype() => Activate();
 
-        private void Activate() => module.Load(dataNode);
-        private void Deactivate() => module.Load(originalNode);
+        private void Activate()
+        {
+            module.Load(dataNode);
+            module.Events.Send("ModuleDataChanged");
+        }
+
+        private void Deactivate()
+        {
+            module.Load(originalNode);
+            module.Events.Send("ModuleDataChanged");
+        }
     }
 }

--- a/B9PartSwitch/PartSwitch/PartModifiers/ModuleDataHandlerBasic.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/ModuleDataHandlerBasic.cs
@@ -29,7 +29,6 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         public override void ActivateOnSwitchFlight() => Activate();
         public override void OnWillBeCopiedActiveSubtype() => Deactivate();
         public override void OnWasCopiedActiveSubtype() => Activate();
-        public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
 
         private void Activate() => module.Load(dataNode);
         private void Deactivate() => module.Load(originalNode);

--- a/B9PartSwitch/PartSwitch/PartModifiers/ModuleDataHandlerBasic.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/ModuleDataHandlerBasic.cs
@@ -8,15 +8,19 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         protected readonly ConfigNode originalNode;
         protected readonly ConfigNode dataNode;
 
-        public ModuleDataHandlerBasic(PartModule module, ConfigNode originalNode, ConfigNode dataNode)
+        private readonly BaseEventDetails moduleDataChangedEventDetails;
+
+        public ModuleDataHandlerBasic(PartModule module, ConfigNode originalNode, ConfigNode dataNode, BaseEventDetails moduleDataChangedEventDetails)
         {
             module.ThrowIfNullArgument(nameof(module));
             originalNode.ThrowIfNullArgument(nameof(originalNode));
             dataNode.ThrowIfNullArgument(nameof(dataNode));
+            moduleDataChangedEventDetails.ThrowIfNullArgument(nameof(moduleDataChangedEventDetails));
 
             this.module = module;
             this.originalNode = originalNode;
             this.dataNode = dataNode;
+            this.moduleDataChangedEventDetails = moduleDataChangedEventDetails;
         }
 
         public override string Description => $"data on module {module}";
@@ -33,13 +37,13 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         private void Activate()
         {
             module.Load(dataNode);
-            module.Events.Send("ModuleDataChanged");
+            module.Events.Send("ModuleDataChanged", moduleDataChangedEventDetails);
         }
 
         private void Deactivate()
         {
             module.Load(originalNode);
-            module.Events.Send("ModuleDataChanged");
+            module.Events.Send("ModuleDataChanged", moduleDataChangedEventDetails);
         }
     }
 }

--- a/B9PartSwitch/PartSwitch/PartModifiers/ModuleDeactivator.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/ModuleDeactivator.cs
@@ -26,7 +26,6 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         public override void ActivateOnSwitchFlight() => Activate();
         public override void OnWillBeCopiedActiveSubtype() => Deactivate();
         public override void OnWasCopiedActiveSubtype() => Activate();
-        public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
 
         protected virtual void Activate()
         {

--- a/B9PartSwitch/PartSwitch/PartModifiers/ModuleOutputResourceResetter.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/ModuleOutputResourceResetter.cs
@@ -23,7 +23,6 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         public override void ActivateOnSwitchFlight() => Fire();
         public override void OnWillBeCopiedActiveSubtype() => Fire();
         public override void OnWasCopiedActiveSubtype() => Fire();
-        public override void OnBeforeReinitializeActiveSubtype() => Fire();
 
         private void Fire() => module.resHandler.outputResources.Clear();
     }

--- a/B9PartSwitch/PartSwitch/PartModifiers/PartModifierBase.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/PartModifierBase.cs
@@ -5,6 +5,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
     public abstract class PartModifierBase : IPartModifier
     {
         public virtual string Description { get; }
+        public virtual bool ChangesGeometry => false;
 
         public virtual void DeactivateOnStartEditor() { }
         public virtual void DeactivateOnStartFlight() { }

--- a/B9PartSwitch/PartSwitch/PartModifiers/PartModifierBase.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/PartModifierBase.cs
@@ -28,5 +28,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         public virtual void OnWasCopiedInactiveSubtype() { }
         public virtual void OnBeforeReinitializeInactiveSubtype() { }
         public virtual void OnBeforeReinitializeActiveSubtype() { }
+        public virtual void OnAfterReinitializeInactiveSubtype() { }
+        public virtual void OnAfterReinitializeActiveSubtype() { }
     }
 }

--- a/B9PartSwitch/PartSwitch/PartModifiers/PartModifierBase.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/PartModifierBase.cs
@@ -4,7 +4,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
 {
     public abstract class PartModifierBase : IPartModifier
     {
-        public virtual string Description { get; }
+        public abstract string Description { get; }
         public virtual bool ChangesGeometry => false;
 
         public virtual void DeactivateOnStartEditor() { }

--- a/B9PartSwitch/PartSwitch/PartModifiers/TextureReplacement.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TextureReplacement.cs
@@ -46,6 +46,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         }
 
         public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
+        public override void OnAfterReinitializeActiveSubtype() => Activate();
 
         private void Activate() => renderer.material.SetTexture(shaderProperty, newTexture);
         private void Deactivate() => renderer.material.SetTexture(shaderProperty, oldTexture);

--- a/B9PartSwitch/PartSwitch/PartModifiers/TransformMover.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TransformMover.cs
@@ -29,6 +29,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         public override void OnWillBeCopiedActiveSubtype() => Deactivate();
         public override void OnWasCopiedActiveSubtype() => Activate();
         public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
+        public override void OnAfterReinitializeActiveSubtype() => Activate();
 
         private void Activate()
         {

--- a/B9PartSwitch/PartSwitch/PartModifiers/TransformMover.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TransformMover.cs
@@ -18,6 +18,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         }
 
         public override string Description => $"transform '{transform.name}' position offset";
+        public override bool ChangesGeometry => true;
 
         public override void ActivateOnStartEditor() => Activate();
         public override void ActivateOnStartFlight() => Activate();

--- a/B9PartSwitch/PartSwitch/PartModifiers/TransformRotator.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TransformRotator.cs
@@ -19,6 +19,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
 
         public override string Description => $"transform '{transform.name}' rotation offset";
         public object PartAspectLock => transform.GetInstanceID() + "---rotation";
+        public override bool ChangesGeometry => true;
 
         public override void ActivateOnStartEditor() => Activate();
         public override void ActivateOnStartFlight() => Activate();

--- a/B9PartSwitch/PartSwitch/PartModifiers/TransformRotator.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TransformRotator.cs
@@ -30,6 +30,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         public override void OnWillBeCopiedActiveSubtype() => Deactivate();
         public override void OnWasCopiedActiveSubtype() => Activate();
         public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
+        public override void OnAfterReinitializeActiveSubtype() => Activate();
 
         private void Activate()
         {

--- a/B9PartSwitch/PartSwitch/PartModifiers/TransformScaleModifier.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TransformScaleModifier.cs
@@ -29,6 +29,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         public override void OnWillBeCopiedActiveSubtype() => Deactivate();
         public override void OnWasCopiedActiveSubtype() => Activate();
         public override void OnBeforeReinitializeActiveSubtype() => Deactivate();
+        public override void OnAfterReinitializeActiveSubtype() => Activate();
 
         private void Activate()
         {

--- a/B9PartSwitch/PartSwitch/PartModifiers/TransformScaleModifier.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TransformScaleModifier.cs
@@ -18,6 +18,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         }
 
         public override string Description => $"transform '{transform.name}' relative scale";
+        public override bool ChangesGeometry => true;
 
         public override void ActivateOnStartEditor() => Activate();
         public override void ActivateOnStartFlight() => Activate();

--- a/B9PartSwitch/PartSwitch/PartModifiers/TransformToggler.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TransformToggler.cs
@@ -17,6 +17,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
             this.part = part;
         }
 
+        public override string Description => $"Transform {transform.name} enabled state";
         public override bool ChangesGeometry => true;
 
         public override void DeactivateOnStartEditor() => Deactivate();

--- a/B9PartSwitch/PartSwitch/PartModifiers/TransformToggler.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/TransformToggler.cs
@@ -17,6 +17,8 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
             this.part = part;
         }
 
+        public override bool ChangesGeometry => true;
+
         public override void DeactivateOnStartEditor() => Deactivate();
         public override void DeactivateOnStartFlight() => Deactivate();
         public override void ActivateOnStartEditor() => Activate();

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -241,6 +241,22 @@ namespace B9PartSwitch
             }
         }
 
+        public void OnAfterReinitializeInactiveSubtype()
+        {
+            foreach (IPartModifier modifier in partModifiers)
+            {
+                modifier.OnAfterReinitializeInactiveSubtype();
+            }
+        }
+
+        public void OnAfterReinitializeActiveSubtype()
+        {
+            foreach (IPartModifier modifier in partModifiers)
+            {
+                modifier.OnAfterReinitializeActiveSubtype();
+            }
+        }
+
         public void Setup(ModuleB9PartSwitch parent, bool displayWarnings = true)
         {
             if (parent == null)

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -139,10 +139,10 @@ namespace B9PartSwitch
 
         public bool HasUpgradeRequired => !upgradeRequired.IsNullOrEmpty();
 
-        public IEnumerable<Transform> Transforms => transforms.Select(transform => transform.transform);
         public IEnumerable<AttachNode> Nodes => nodes.All();
         public IEnumerable<string> ResourceNames => tankType.ResourceNames;
         public IEnumerable<string> NodeIDs => nodes.Select(n => n.id);
+        public bool ChangesGeometry => partModifiers.Any(modifier => modifier.ChangesGeometry);
 
         public bool ChangesDryMass => addedMass != 0 || tankType.tankMass != 0;
         public bool ChangesMass => (addedMass != 0f) || tankType.ChangesMass;

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -439,7 +439,7 @@ namespace B9PartSwitch
                 {
                     try
                     {
-                        foreach (IPartModifier partModifier in moduleModifierInfo.CreatePartModifiers(part, parent))
+                        foreach (IPartModifier partModifier in moduleModifierInfo.CreatePartModifiers(part, parent, parent.CreateModuleDataChangedEventDetails()))
                         {
                             MaybeAddModifier(partModifier);
                         }

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -139,9 +139,7 @@ namespace B9PartSwitch
 
         public bool HasUpgradeRequired => !upgradeRequired.IsNullOrEmpty();
 
-        public IEnumerable<AttachNode> Nodes => nodes.All();
         public IEnumerable<string> ResourceNames => tankType.ResourceNames;
-        public IEnumerable<string> NodeIDs => nodes.Select(n => n.id);
         public bool ChangesGeometry => partModifiers.Any(modifier => modifier.ChangesGeometry);
 
         public bool ChangesDryMass => addedMass != 0 || tankType.tankMass != 0;

--- a/B9PartSwitch/Utils/ChangeTransactionManager.cs
+++ b/B9PartSwitch/Utils/ChangeTransactionManager.cs
@@ -1,0 +1,71 @@
+﻿using System;
+
+namespace B9PartSwitch.Utils
+{
+    public class ChangeTransactionManager
+    {
+        private enum TransactionState
+        {
+            PreInitialize,
+            OutsideTransactionNoChangeNeeded,
+            InTransactionNoChangeNeeded,
+            InTransactionChangeNeeded,
+            AfterTransactionChanging,
+        }
+
+        private TransactionState state = TransactionState.PreInitialize;
+        private readonly Action change;
+
+        public ChangeTransactionManager(Action change)
+        {
+            this.change = change ?? throw new ArgumentNullException(nameof(change));
+        }
+
+        public void Initialize()
+        {
+            if (state != TransactionState.PreInitialize) return;
+            state = TransactionState.OutsideTransactionNoChangeNeeded;
+        }
+
+        public void RequestChange()
+        {
+            if (state == TransactionState.PreInitialize) return;
+
+            if (state == TransactionState.InTransactionNoChangeNeeded)
+            {
+                state = TransactionState.InTransactionChangeNeeded;
+            }
+            else if (state == TransactionState.OutsideTransactionNoChangeNeeded)
+            {
+                change();
+            }
+            else if (state == TransactionState.AfterTransactionChanging)
+            {
+                throw new InvalidOperationException("Circular change condition detected");
+            }
+        }
+
+        public void WithTransaction(Action action)
+        {
+            if (action == null) throw new ArgumentNullException(nameof(action));
+
+            if (state == TransactionState.OutsideTransactionNoChangeNeeded || state == TransactionState.PreInitialize)
+                state = TransactionState.InTransactionNoChangeNeeded;
+
+            try
+            {
+                action();
+
+                if (state == TransactionState.InTransactionChangeNeeded)
+                {
+                    state = TransactionState.AfterTransactionChanging;
+                    change();
+                }
+            }
+            finally
+            {
+                state = TransactionState.OutsideTransactionNoChangeNeeded;
+            }
+        }
+    }
+}

--- a/B9PartSwitchTests/B9PartSwitchTests.csproj
+++ b/B9PartSwitchTests/B9PartSwitchTests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="TestUtils\DummyTypes\DummyIContextualNodeTest.cs" />
     <Compile Include="TestUtils\TestConfigNode.cs" />
     <Compile Include="TestUtils\TestConfigNodeTest.cs" />
+    <Compile Include="Utils\ChangeTransactionManagerTest.cs" />
     <Compile Include="Utils\ColorParserTest.cs" />
     <Compile Include="Utils\GroupedStringBuilderTest.cs" />
   </ItemGroup>

--- a/B9PartSwitchTests/Utils/ChangeTransactionManagerTest.cs
+++ b/B9PartSwitchTests/Utils/ChangeTransactionManagerTest.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using B9PartSwitch.Utils;
+
+namespace B9PartSwitchTests.Utils
+{
+    public class ChangeTransactionManagerTest
+    {
+        [Fact]
+        public void TestConstructor__Null()
+        {
+            Assert.Throws<ArgumentNullException>(delegate
+            {
+                new ChangeTransactionManager(null);
+            });
+        }
+
+        [Fact]
+        public void TestRequestChange__NotYetInitialized()
+        {
+            int counter = 0;
+            ChangeTransactionManager transactionManager = new ChangeTransactionManager(() => counter += 1);
+            transactionManager.RequestChange();
+            Assert.Equal(0, counter);
+        }
+
+        [Fact]
+        public void TestRequestChange__OutsideTransaction()
+        {
+            int counter = 0;
+            ChangeTransactionManager transactionManager = new ChangeTransactionManager(() => counter += 1);
+            transactionManager.Initialize();
+            transactionManager.RequestChange();
+            Assert.Equal(1, counter);
+        }
+
+        [Fact]
+        public void TestWithTransaction__NoRequestChange()
+        {
+            int counter = 0;
+            ChangeTransactionManager transactionManager = new ChangeTransactionManager(() => counter += 1);
+            transactionManager.WithTransaction(delegate
+            {
+                Assert.Equal(0, counter);
+            });
+
+            Assert.Equal(0, counter);
+        }
+
+        [Fact]
+        public void TestWithTransaction__RequestChange()
+        {
+            int counter = 0;
+            ChangeTransactionManager transactionManager = new ChangeTransactionManager(() => counter += 1);
+            transactionManager.WithTransaction(delegate
+            {
+                transactionManager.RequestChange();
+                transactionManager.RequestChange();
+                Assert.Equal(0, counter);
+            });
+
+            Assert.Equal(1, counter);
+        }
+
+        [Fact]
+        public void TestWithTransaction__RequestChange__AlreadyChanging()
+        {
+            ChangeTransactionManager transactionManager = null;
+            transactionManager = new ChangeTransactionManager(() => transactionManager.RequestChange());
+            Assert.Throws<InvalidOperationException>(delegate
+            {
+                transactionManager.WithTransaction(delegate
+                {
+                    transactionManager.RequestChange();
+                });
+            });
+        }
+
+        [Fact]
+        public void TestWithTransaction__Null()
+        {
+            ChangeTransactionManager transactionManager = new ChangeTransactionManager(() => throw new Exception());
+            Assert.Throws<ArgumentNullException>(delegate
+            {
+                transactionManager.WithTransaction(null);
+            });
+        }
+    }
+}

--- a/B9PartSwitchTests/Utils/ChangeTransactionManagerTest.cs
+++ b/B9PartSwitchTests/Utils/ChangeTransactionManagerTest.cs
@@ -81,6 +81,27 @@ namespace B9PartSwitchTests.Utils
         }
 
         [Fact]
+        public void TestWithTransaction__Throws()
+        {
+            int counter = 0;
+            ChangeTransactionManager transactionManager = new ChangeTransactionManager(() => counter += 1);
+            Exception ex1 = new Exception();
+            Exception ex2 = Assert.Throws<Exception>(delegate
+            {
+                transactionManager.WithTransaction(delegate
+                {
+                    throw ex1;
+                });
+            });
+
+            Assert.Equal(0, counter);
+            Assert.Same(ex1, ex2);
+
+            transactionManager.RequestChange();
+            Assert.Equal(1, counter);
+        }
+
+        [Fact]
         public void TestWithTransaction__Null()
         {
             ChangeTransactionManager transactionManager = new ChangeTransactionManager(() => throw new Exception());


### PR DESCRIPTION
* Only call reinitialize lifecycle methods on modules that need it (those where not doing so would cause the resource to become unidentifyable)
* Ensure that reinitialization happens at the end of a switch cycle, not during it
* Send `ModuleDataChanged` to modules that have had their data changed
  * Include two attributes in the event details, `requestNotifyFARToRevoxelize` and `requestRecalculateDragCubes`, which can be used to request FAR/drag cubes updates at the end of the cycle
* Transform move/rotation/scale now affect drag cubes/FAR
* Do aero updates in `OnStartFinished`
  * Eliminates need for special logic for root part in flight
  * Eliminates last part logic
* Send/listen for `DragCubesWereRecalculated` and `FarWasNotifiedToRevoxelize` to make sure actions are only done once per cycle