### PR TITLE
Attach node size and more flexible matching

### DIFF
--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Fishbones\OperationManager.cs" />
     <Compile Include="Fishbones\UseParser.cs" />
     <Compile Include="Localization.cs" />
+    <Compile Include="PartSwitch\PartModifiers\AttachNodeSizeModifier.cs" />
     <Compile Include="Utils\ChangeTransactionManager.cs" />
     <Compile Include="ModuleB9DisableTransform.cs" />
     <Compile Include="ModuleB9PropagateCopyEvents.cs" />

--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Utils\ColorParser.cs" />
     <Compile Include="Utils\GroupedStringBuilder.cs" />
     <Compile Include="Utils\ResourceColors.cs" />
+    <Compile Include="Utils\StringMatcher.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/B9PartSwitch/Extensions/PartExtensions.cs
+++ b/B9PartSwitch/Extensions/PartExtensions.cs
@@ -123,14 +123,6 @@ namespace B9PartSwitch
             return part.partTransform.Find("model");
         }
 
-        public static IEnumerable<Transform> GetModelTransforms(this Part part, string name)
-        {
-            part.ThrowIfNullArgument(nameof(part));
-            name.ThrowIfNullOrEmpty(nameof(name));
-
-            return part.GetModelRoot().GetChildrenNamedRecursive(name);
-        }
-
         public static void FixModuleJettison(this Part part)
         {
             if (!HighLogic.LoadedSceneIsFlight) return;

--- a/B9PartSwitch/Extensions/TransformExtensions.cs
+++ b/B9PartSwitch/Extensions/TransformExtensions.cs
@@ -8,18 +8,17 @@ namespace B9PartSwitch
         public static void Enable(this Transform trans) => trans.gameObject.SetActive(true);
         public static void Disable(this Transform trans) => trans.gameObject.SetActive(false);
 
-        public static IEnumerable<Transform> GetChildrenNamedRecursive(this Transform transform, string name)
+        public static IEnumerable<Transform> TraverseHierarchy(this Transform transform)
         {
             transform.ThrowIfNullArgument(nameof(transform));
-            name.ThrowIfNullOrEmpty(nameof(name));
 
             for (int i = 0; i < transform.childCount; i++)
             {
                 Transform child = transform.GetChild(i);
 
-                if (child.name == name) yield return child;
+                yield return child;
 
-                foreach (Transform childChild in child.GetChildrenNamedRecursive(name))
+                foreach (Transform childChild in child.TraverseHierarchy())
                 {
                     yield return childChild;
                 }

--- a/B9PartSwitch/Fishbones/Parsers/DefaultValueParseMap.cs
+++ b/B9PartSwitch/Fishbones/Parsers/DefaultValueParseMap.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using UnityEngine;
+using B9PartSwitch.Utils;
 
 namespace B9PartSwitch.Fishbones.Parsers
 {
@@ -30,6 +31,8 @@ namespace B9PartSwitch.Fishbones.Parsers
         public static readonly IValueParser Matrix4x4Parser = new ValueParser<Matrix4x4>(ConfigNode.ParseMatrix4x4, ConfigNode.WriteMatrix4x4);
         public static readonly IValueParser ColorParser = new ValueParser<Color>(Utils.ColorParser.Parse, ConfigNode.WriteColor);
         public static readonly IValueParser Color32Parser = new ValueParser<Color32>(ConfigNode.ParseColor32, ConfigNode.WriteColor);
+
+        public static readonly IValueParser StringMatcherParser = new ValueParser<IStringMatcher>(StringMatcher.Parse, s => s.ToString());
 
         public static readonly IValueParser AttachNodeParser = new AttachNodeValueParser();
         public static readonly IValueParser PartResourceDefinitionParser = new PartResourceDefinitionValueParser();
@@ -62,6 +65,8 @@ namespace B9PartSwitch.Fishbones.Parsers
             AddParser(Matrix4x4Parser);
             AddParser(ColorParser);
             AddParser(Color32Parser);
+
+            AddParser(StringMatcherParser);
 
             AddParser(AttachNodeParser);
             AddParser(PartResourceDefinitionParser);

--- a/B9PartSwitch/PartSwitch/AttachNodeModifierInfo.cs
+++ b/B9PartSwitch/PartSwitch/AttachNodeModifierInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using B9PartSwitch.Fishbones;
@@ -25,15 +26,14 @@ namespace B9PartSwitch
             this.SaveFields(node, context);
         }
 
-        public AttachNodeMover CreateAttachNodeModifier(Part part, ILinearScaleProvider linearScaleProvider, Action<string> onError)
+        public IEnumerable<IPartModifier> CreatePartModifiers(Part part, ILinearScaleProvider linearScaleProvider, Action<string> onError)
         {
-            if (position == null) return null;
             AttachNode node = part.attachNodes.FirstOrDefault(n => (n.nodeType == AttachNode.NodeType.Stack || n.nodeType == AttachNode.NodeType.Dock) && n.id == nodeID);
 
             if (node == null)
             {
                 onError($"Attach node with id '{nodeID}' not found for attach node modifier");
-                return null;
+                yield break;
             }
 
             // Explanation
@@ -44,7 +44,7 @@ namespace B9PartSwitch
             Part maybePrefab = part.partInfo?.partPrefab ?? part;
             float fixedScale = maybePrefab.scaleFactor * maybePrefab.rescaleFactor * maybePrefab.rescaleFactor;
 
-            return new AttachNodeMover(node, position.Value * fixedScale, linearScaleProvider);
+            if (position != null) yield return new AttachNodeMover(node, position.Value * fixedScale, linearScaleProvider);
         }
     }
 }

--- a/B9PartSwitch/PartSwitch/AttachNodeModifierInfo.cs
+++ b/B9PartSwitch/PartSwitch/AttachNodeModifierInfo.cs
@@ -5,13 +5,14 @@ using UnityEngine;
 using B9PartSwitch.Fishbones;
 using B9PartSwitch.Fishbones.Context;
 using B9PartSwitch.PartSwitch.PartModifiers;
+using B9PartSwitch.Utils;
 
 namespace B9PartSwitch
 {
     public class AttachNodeModifierInfo : IContextualNode
     {
         [NodeData(name = "name")]
-        public string nodeID;
+        public IStringMatcher nodeID;
 
         [NodeData]
         public Vector3? position;
@@ -31,11 +32,11 @@ namespace B9PartSwitch
 
         public IEnumerable<IPartModifier> CreatePartModifiers(Part part, ILinearScaleProvider linearScaleProvider, Action<string> onError)
         {
-            AttachNode node = part.attachNodes.FirstOrDefault(n => (n.nodeType == AttachNode.NodeType.Stack || n.nodeType == AttachNode.NodeType.Dock) && n.id == nodeID);
+            AttachNode node = part.attachNodes.FirstOrDefault(n => (n.nodeType == AttachNode.NodeType.Stack || n.nodeType == AttachNode.NodeType.Dock) && nodeID.Match(n.id));
 
             if (node == null)
             {
-                onError($"Attach node with id '{nodeID}' not found for attach node modifier");
+                onError($"Attach node with id matching '{nodeID}' not found for attach node modifier");
                 yield break;
             }
 

--- a/B9PartSwitch/PartSwitch/AttachNodeModifierInfo.cs
+++ b/B9PartSwitch/PartSwitch/AttachNodeModifierInfo.cs
@@ -16,6 +16,9 @@ namespace B9PartSwitch
         [NodeData]
         public Vector3? position;
 
+        [NodeData]
+        public int? size;
+
         public void Load(ConfigNode node, OperationContext context)
         {
             this.LoadFields(node, context);
@@ -45,6 +48,7 @@ namespace B9PartSwitch
             float fixedScale = maybePrefab.scaleFactor * maybePrefab.rescaleFactor * maybePrefab.rescaleFactor;
 
             if (position != null) yield return new AttachNodeMover(node, position.Value * fixedScale, linearScaleProvider);
+            if (size != null) yield return new AttachNodeSizeModifier(node, size.Value, linearScaleProvider);
         }
     }
 }

--- a/B9PartSwitch/PartSwitch/MaterialModifierInfo.cs
+++ b/B9PartSwitch/PartSwitch/MaterialModifierInfo.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using B9PartSwitch.Fishbones;
 using B9PartSwitch.Fishbones.Context;
 using B9PartSwitch.PartSwitch.PartModifiers;
+using B9PartSwitch.Utils;
 
 namespace B9PartSwitch
 {
@@ -14,10 +15,10 @@ namespace B9PartSwitch
         public string name;
 
         [NodeData(name = "baseTransform")]
-        public List<string> baseTransformNames = new List<string>();
+        public List<IStringMatcher> baseTransformNames = new List<IStringMatcher>();
 
         [NodeData(name = "transform")]
-        public List<string> transformNames = new List<string>();
+        public List<IStringMatcher> transformNames = new List<IStringMatcher>();
 
         [NodeData(name = "FLOAT")]
         public List<FloatPropertyModifierInfo> floatPropertyModifierInfos = new List<FloatPropertyModifierInfo>();
@@ -79,11 +80,11 @@ namespace B9PartSwitch
             IEnumerable<Renderer> result = Enumerable.Empty<Renderer>();
             if (baseTransformNames == null) return result;
 
-            foreach (string baseTransformName in baseTransformNames)
+            foreach (IStringMatcher baseTransformName in baseTransformNames)
             {
                 bool foundTransform = false;
 
-                foreach (Transform transform in rootTransform.GetChildrenNamedRecursive(baseTransformName))
+                foreach (Transform transform in rootTransform.TraverseHierarchy().Where(t => baseTransformName.Match(t.name)))
                 {
                     foundTransform = true;
 
@@ -98,7 +99,7 @@ namespace B9PartSwitch
                     result = result.Concat(transformRenderers);
                 }
 
-                if (!foundTransform) onError($"No transforms named '{baseTransformName}' found");
+                if (!foundTransform) onError($"No transforms matching '{baseTransformName}' found");
             }
 
             return result;
@@ -109,11 +110,11 @@ namespace B9PartSwitch
             IEnumerable<Renderer> result = Enumerable.Empty<Renderer>();
             if (transformNames == null) return result;
 
-            foreach (string transformName in transformNames)
+            foreach (IStringMatcher transformName in transformNames)
             {
                 bool foundTransform = false;
 
-                foreach (Transform transform in rootTransform.GetChildrenNamedRecursive(transformName))
+                foreach (Transform transform in rootTransform.TraverseHierarchy().Where(t => transformName.Match(t.name)))
                 {
                     foundTransform = true;
                     Renderer[] transformRenderers = transform.GetComponents<Renderer>();
@@ -127,7 +128,7 @@ namespace B9PartSwitch
                     result = result.Concat(transformRenderers);
                 }
 
-                if (!foundTransform) onError($"No transforms named '{transformName}' found");
+                if (!foundTransform) onError($"No transforms matching '{transformName}' found");
             }
 
             return result;

--- a/B9PartSwitch/PartSwitch/ModuleModifierInfo.cs
+++ b/B9PartSwitch/PartSwitch/ModuleModifierInfo.cs
@@ -245,7 +245,10 @@ namespace B9PartSwitch
 
         private bool NodeMatchesModule(PartModule module, IStringMatcher moduleName, ConfigNode node)
         {
-            if (!moduleName.Match(node.GetValue("name"))) return false;
+            string nameValue = node.GetValue("name");
+            if (nameValue.IsNullOrEmpty()) throw new ArgumentException("Cannot match a module node without a name!");
+
+            if (!moduleName.Match(nameValue)) return false;
 
             foreach (ConfigNode.Value value in identifierNode.values)
             {

--- a/B9PartSwitch/PartSwitch/ModuleModifierInfo.cs
+++ b/B9PartSwitch/PartSwitch/ModuleModifierInfo.cs
@@ -6,6 +6,7 @@ using B9PartSwitch.Fishbones;
 using B9PartSwitch.Fishbones.Context;
 using B9PartSwitch.Fishbones.Parsers;
 using B9PartSwitch.PartSwitch.PartModifiers;
+using B9PartSwitch.Utils;
 
 namespace B9PartSwitch
 {
@@ -97,14 +98,16 @@ namespace B9PartSwitch
 
             if (moduleName == string.Empty) throw new Exception ("IDENTIFIER node has a blank name");
 
-            PartModule module = FindModule(part, parentModule, moduleName);
+            IStringMatcher moduleNameMatcher = StringMatcher.Parse(moduleName);
+
+            PartModule module = FindModule(part, parentModule, moduleNameMatcher);
 
             if (dataNode.IsNotNull())
             {
                 if (!(module.part.partInfo is AvailablePart partInfo)) throw new InvalidOperationException($"partInfo is null on part {part.name}");
                 if (!(partInfo.partConfig is ConfigNode partConfig)) throw new InvalidOperationException($"partInfo.partConfig is null on part {partInfo.name}");
 
-                ConfigNode originalNode = FindPrefabNode(module, moduleName);
+                ConfigNode originalNode = FindPrefabNode(module, moduleNameMatcher);
 
                 if (INVALID_MODULES_FOR_DATA_LOADING.Any(type => module.GetType().Implements(type)))
                     throw new InvalidOperationException($"Cannot modify data on {module.GetType()}");
@@ -151,7 +154,7 @@ namespace B9PartSwitch
             }
         }
 
-        private PartModule FindModule(Part part, PartModule parentModule, string moduleName)
+        private PartModule FindModule(Part part, PartModule parentModule, IStringMatcher moduleName)
         {
             PartModule matchedModule = null;
 
@@ -171,7 +174,7 @@ namespace B9PartSwitch
             return matchedModule;
         }
 
-        private ConfigNode FindPrefabNode(PartModule module, string moduleName)
+        private ConfigNode FindPrefabNode(PartModule module, IStringMatcher moduleName)
         {
             if (!(module.part.partInfo is AvailablePart partInfo)) throw new InvalidOperationException($"partInfo is null on part {module.part.name}");
             if (!(partInfo.partConfig is ConfigNode partConfig)) throw new InvalidOperationException($"partInfo.partConfig is null on part {partInfo.name}");
@@ -194,9 +197,9 @@ namespace B9PartSwitch
             return matchedNode;
         }
 
-        private bool IsMatch(PartModule module, string moduleName)
+        private bool IsMatch(PartModule module, IStringMatcher moduleName)
         {
-            if (module.GetType().Name != moduleName) return false;
+            if (!moduleName.Match(module.GetType().Name)) return false;
 
             foreach (ConfigNode.Value value in identifierNode.values)
             {
@@ -240,9 +243,9 @@ namespace B9PartSwitch
             return true;
         }
 
-        private bool NodeMatchesModule(PartModule module, string moduleName, ConfigNode node)
+        private bool NodeMatchesModule(PartModule module, IStringMatcher moduleName, ConfigNode node)
         {
-            if (node.GetValue("name") != moduleName) return false;
+            if (!moduleName.Match(node.GetValue("name"))) return false;
 
             foreach (ConfigNode.Value value in identifierNode.values)
             {

--- a/B9PartSwitch/PartSwitch/ModuleModifierInfo.cs
+++ b/B9PartSwitch/PartSwitch/ModuleModifierInfo.cs
@@ -180,6 +180,8 @@ namespace B9PartSwitch
 
             foreach (ConfigNode subNode in partConfig.nodes)
             {
+                if (subNode.name != "MODULE") continue;
+
                 if (!NodeMatchesModule(module, moduleName, subNode)) continue;
 
                 if (matchedNode.IsNotNull()) throw new Exception("Found more than one matching module node");

--- a/B9PartSwitch/PartSwitch/PartModifiers/AttachNodeMover.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/AttachNodeMover.cs
@@ -20,7 +20,7 @@ namespace B9PartSwitch.PartSwitch.PartModifiers
         }
 
         public object PartAspectLock => attachNode.id + "---position";
-        public override string Description => $"attach node '{attachNode.id}'";
+        public override string Description => $"attach node '{attachNode.id}' position";
 
         public override void ActivateOnStartEditor() => SetAttachNodePosition();
         public override void ActivateOnStartFlight() => SetAttachNodePosition();

--- a/B9PartSwitch/PartSwitch/PartModifiers/AttachNodeSizeModifier.cs
+++ b/B9PartSwitch/PartSwitch/PartModifiers/AttachNodeSizeModifier.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using UnityEngine;
+
+namespace B9PartSwitch.PartSwitch.PartModifiers
+{
+    public class AttachNodeSizeModifier : PartModifierBase, IPartAspectLock
+    {
+        public readonly AttachNode attachNode;
+        private readonly int originalSize;
+        private readonly int size;
+        private readonly ILinearScaleProvider linearScaleProvider;
+
+        public AttachNodeSizeModifier(AttachNode attachNode, int size, ILinearScaleProvider linearScaleProvider)
+        {
+            attachNode.ThrowIfNullArgument(nameof(attachNode));
+            linearScaleProvider.ThrowIfNullArgument(nameof(linearScaleProvider));
+
+            this.attachNode = attachNode;
+            this.size = size;
+            this.linearScaleProvider = linearScaleProvider;
+
+            originalSize = attachNode.size;
+        }
+
+        public object PartAspectLock => attachNode.id + "---size";
+        public override string Description => $"attach node '{attachNode.id}' size";
+
+        public override void ActivateOnStartEditor() => SetAttachNodeSize();
+        public override void ActivateOnStartFlight() => SetAttachNodeSize();
+
+        // Wait until OnStartFinished thanks to TweakScale
+        public override void ActivateOnStartFinishedEditor() => SetAttachNodeSize();
+        public override void ActivateOnStartFinishedFlight() => SetAttachNodeSize();
+
+        public override void ActivateOnSwitchEditor() => SetAttachNodeSize();
+        public override void ActivateOnSwitchFlight() => SetAttachNodeSize();
+        public override void DeactivateOnSwitchEditor() => UnsetAttachNodeSize();
+        public override void DeactivateOnSwitchFlight() => UnsetAttachNodeSize();
+        public override void OnBeforeReinitializeActiveSubtype() => UnsetAttachNodeSize();
+        public override void OnAfterReinitializeActiveSubtype() => SetAttachNodeSize();
+
+        private void SetAttachNodeSize() => attachNode.size = Mathf.RoundToInt(size * linearScaleProvider.LinearScale);
+        private void UnsetAttachNodeSize() => attachNode.size = Mathf.RoundToInt(originalSize * linearScaleProvider.LinearScale);
+    }
+}

--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -351,7 +351,10 @@ namespace B9PartSwitch
 
             foreach (AttachNodeModifierInfo info in attachNodeModifierInfos)
             {
-                MaybeAddModifier(info.CreateAttachNodeModifier(part, parent, OnInitializationError));
+                foreach(IPartModifier partModifier in info.CreatePartModifiers(part, parent, OnInitializationError))
+                {
+                    MaybeAddModifier(partModifier);
+                }
             }
 
             foreach (TextureSwitchInfo info in textureSwitches)

--- a/B9PartSwitch/PartSwitch/TextureSwitchInfo.cs
+++ b/B9PartSwitch/PartSwitch/TextureSwitchInfo.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using B9PartSwitch.Fishbones;
 using B9PartSwitch.Fishbones.Context;
 using B9PartSwitch.PartSwitch.PartModifiers;
+using B9PartSwitch.Utils;
 
 namespace B9PartSwitch
 {
@@ -14,10 +15,10 @@ namespace B9PartSwitch
         public string currentTextureName;
 
         [NodeData(name = "baseTransform")]
-        public List<string> baseTransformNames;
+        public List<IStringMatcher> baseTransformNames;
 
         [NodeData(name = "transform")]
-        public List<string> transformNames;
+        public List<IStringMatcher> transformNames;
 
         [NodeData(name = "texture")]
         public string newTexturePath;
@@ -97,11 +98,11 @@ namespace B9PartSwitch
             IEnumerable<Renderer> result = Enumerable.Empty<Renderer>();
             if (baseTransformNames == null) return result;
 
-            foreach (string baseTransformName in baseTransformNames)
+            foreach (IStringMatcher baseTransformName in baseTransformNames)
             {
                 bool foundTransform = false;
 
-                foreach (Transform transform in part.GetModelTransforms(baseTransformName))
+                foreach (Transform transform in part.GetModelRoot().TraverseHierarchy().Where(t => baseTransformName.Match(t.name)))
                 {
                     foundTransform = true;
 
@@ -116,7 +117,7 @@ namespace B9PartSwitch
                     result = result.Concat(transformRenderers);
                 }
 
-                if (!foundTransform) onError($"No transforms named '{baseTransformName}' found");
+                if (!foundTransform) onError($"No transforms matching '{baseTransformName}' found");
             }
 
             return result;
@@ -127,11 +128,11 @@ namespace B9PartSwitch
             IEnumerable<Renderer> result = Enumerable.Empty<Renderer>();
             if (transformNames == null) return result;
 
-            foreach (string transformName in transformNames)
+            foreach (IStringMatcher transformName in transformNames)
             {
                 bool foundTransform = false;
 
-                foreach (Transform transform in part.GetModelTransforms(transformName))
+                foreach (Transform transform in part.GetModelRoot().TraverseHierarchy().Where(t => transformName.Match(t.name)))
                 {
                     foundTransform = true;
                     Renderer[] transformRenderers = transform.GetComponents<Renderer>();
@@ -145,7 +146,7 @@ namespace B9PartSwitch
                     result = result.Concat(transformRenderers);
                 }
 
-                if (!foundTransform) onError($"No transforms named '{transformName}' found");
+                if (!foundTransform) onError($"No transforms matching '{transformName}' found");
             }
 
             return result;

--- a/B9PartSwitch/PartSwitch/TransformModifierInfo.cs
+++ b/B9PartSwitch/PartSwitch/TransformModifierInfo.cs
@@ -1,16 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using B9PartSwitch.Fishbones;
 using B9PartSwitch.Fishbones.Context;
 using B9PartSwitch.PartSwitch.PartModifiers;
+using B9PartSwitch.Utils;
 
 namespace B9PartSwitch
 {
     public class TransformModifierInfo : IContextualNode
     {
         [NodeData(name = "name")]
-        public string transformName;
+        public IStringMatcher transformName;
 
         [NodeData]
         public Vector3? positionOffset;
@@ -30,15 +32,15 @@ namespace B9PartSwitch
             part.ThrowIfNullArgument(nameof(part));
             onError.ThrowIfNullArgument(nameof(onError));
 
-            if (string.IsNullOrEmpty(transformName))
+            if (transformName == null)
             {
-                onError("transform name is empty");
+                onError("transform name is null");
                 yield break;
             }
 
             bool foundTransform = false;
 
-            foreach (Transform transform in part.GetModelTransforms(transformName))
+            foreach (Transform transform in part.GetModelRoot().TraverseHierarchy().Where(t => transformName.Match(t.name)))
             {
                 foundTransform = true;
 

--- a/B9PartSwitch/Utils/StringMatcher.cs
+++ b/B9PartSwitch/Utils/StringMatcher.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace B9PartSwitch.Utils
+{
+    public static class StringMatcher
+    {
+        public static IStringMatcher Parse(string str)
+        {
+            str.ThrowIfNullArgument(nameof(str));
+
+            if (str.Length > 2 && str[0] == '/' && str[str.Length - 1] == '/')
+            {
+                Regex regex = new Regex(str.Substring(1, str.Length - 2));
+                return new RegexStringMatcher(regex);
+            }
+
+            if (str.Length > 2 && str[0] == '\\' && str[1] == '/') str = str.Substring(1);
+
+            if (str.IndexOf('*') != -1 || str.IndexOf('?') != -1)
+            {
+                str = Regex.Escape(str).Replace("\\*", ".*").Replace("\\?", ".");
+                Regex regex = new Regex('^' + str + '$');
+                return new RegexStringMatcher(regex);
+            }
+
+            return new NormalStringMatcher(str);
+        }
+    }
+
+    public interface IStringMatcher
+    {
+        bool Match(string testMatch);
+    }
+
+    public class NormalStringMatcher : IStringMatcher
+    {
+        private readonly string str;
+
+        public NormalStringMatcher(string str)
+        {
+            this.str = str ?? throw new ArgumentNullException(nameof(str));
+        }
+
+        public bool Match(string testMatch)
+        {
+            testMatch.ThrowIfNullArgument(nameof(testMatch));
+
+            return testMatch == str;
+        }
+
+        public override string ToString()
+        {
+            if (str.Length > 2 && str[0] == '/' && str[str.Length - 1] == '/')
+                return '\\' + str;
+            else
+                return str;
+        }
+    }
+
+    public class RegexStringMatcher : IStringMatcher
+    {
+        private readonly Regex regex;
+
+        public RegexStringMatcher(Regex regex)
+        {
+            this.regex = regex ?? throw new ArgumentNullException(nameof(regex));
+        }
+
+        public bool Match(string testMatch)
+        {
+            testMatch.ThrowIfNullArgument(nameof(testMatch));
+
+            return regex.IsMatch(testMatch);
+        }
+
+        public override string ToString() => $"/{regex}/";
+    }
+}

--- a/B9PartSwitchTests/B9PartSwitchTests.csproj
+++ b/B9PartSwitchTests/B9PartSwitchTests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Utils\ChangeTransactionManagerTest.cs" />
     <Compile Include="Utils\ColorParserTest.cs" />
     <Compile Include="Utils\GroupedStringBuilderTest.cs" />
+    <Compile Include="Utils\StringMatcherTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/B9PartSwitchTests/Fishbones/Parsers/DefaultValueParseMapTest.cs
+++ b/B9PartSwitchTests/Fishbones/Parsers/DefaultValueParseMapTest.cs
@@ -2,6 +2,7 @@
 using Xunit;
 using UnityEngine;
 using B9PartSwitch.Fishbones.Parsers;
+using B9PartSwitch.Utils;
 
 namespace B9PartSwitchTests.Fishbones.Parsers
 {
@@ -46,6 +47,7 @@ namespace B9PartSwitchTests.Fishbones.Parsers
                 typeof(Matrix4x4),
                 typeof(Color),
                 typeof(Color32),
+                typeof(IStringMatcher),
                 typeof(AttachNode),
                 typeof(PartResourceDefinition),
             };

--- a/B9PartSwitchTests/Utils/StringMatcherTest.cs
+++ b/B9PartSwitchTests/Utils/StringMatcherTest.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Xunit;
+using B9PartSwitch.Utils;
+
+namespace B9PartSwitchTests.Utils
+{
+    public class StringMatcherTest
+    {
+        [Fact]
+        public void TestParse__NullArgument()
+        {
+            Assert.Throws<ArgumentNullException>(delegate
+            {
+                IStringMatcher matcher = StringMatcher.Parse(null);
+            });
+        }
+
+        [Theory]
+        [InlineData("", "", true)]
+        [InlineData("", "not empty", false)]
+        [InlineData("a string", "a string", true)]
+        [InlineData("a string", "", false)]
+        [InlineData("a string", "a string within a string", false)]
+        [InlineData("a*string", "astring", true)]
+        [InlineData("a*string", "a longer string", true)]
+        [InlineData("a*string", "", false)]
+        [InlineData("a*string", "not a string", false)]
+        [InlineData("a?string", "a string", true)]
+        [InlineData("a?string", "a-string", true)]
+        [InlineData("a?string", "aastring", true)]
+        [InlineData("a?string", "astring", false)]
+        [InlineData("a?string", "any string", false)]
+        [InlineData("a*string.*", "a string.*", true)]
+        [InlineData("a*string.*", "a string and stuff", false)]
+        [InlineData("/a(?:\\slonger)?\\sstring/", "a string", true)]
+        [InlineData("/a(?:\\slonger)?\\sstring/", "a longer string", true)]
+        [InlineData("/a(?:\\slonger)?\\sstring/", "alongerstring", false)]
+        [InlineData("/a(?:\\slonger)?\\sstring/", "a different string", false)]
+        [InlineData("/a(?:\\slonger)?\\sstring/", "", false)]
+        [InlineData("\\/a/path/", "/a/path/", true)]
+        [InlineData("\\/a/path/", "a/path", false)]
+        [InlineData("\\/a/path/", "", false)]
+        public void TestParse__Match__ToString(string matchString, string testSting, bool result)
+        {
+            IStringMatcher matcher = StringMatcher.Parse(matchString);
+            Assert.Equal(result, matcher.Match(testSting));
+
+            Assert.Throws<ArgumentNullException>(delegate
+            {
+                matcher.Match(null);
+            });
+
+            string otherString = matcher.ToString();
+            IStringMatcher matcher2 = StringMatcher.Parse(otherString);
+            Assert.Equal(result, matcher2.Match(testSting));
+        }
+    }
+}


### PR DESCRIPTION
* Implement node size modifier
  * `SUBTYPE` -> `NODE` -> `size`
  * Accepts integers
  * Will be scaled and rounded by TweakScale
* Allow more flexible matching of various names
  * If it starts and ends with /, treat it as a regular expression
  * If it contains * or ?, treat those as wildcards (anything or one character respectively)
  * Otherwise treat it as a normal string
    * If it starts with `\`, the next character is `/`, and it ends with `/`, eliminate the leading `\`
  * Use in the following places:
    * attach node modifier node name (`SUBTYPE` -> `NODE` -> `name`)
    * transform toggle name (`SUBTYPE` -> `transform`)
    * node toggler name (`SUBTYPE` -> `node`)
    * material modifier transform names (`SUBTYPE` -> `MATERIAL` -> `transform`/`baseTransform`)
    * texture modifier transform names (`SUBTYPE` -> `TEXTURE` -> `transform`/`baseTransform`)
    * module modifier name (`SUBTYPE` -> `MODULE` -> `MODIFIER` -> `name`)
    * transform modifier transform names (`SUBTYPE` -> `TRANSFORM` -> `name`)
* Fix attach node mover description for error messages