### PR TITLE
QoL improvements for parts with a large number of subtypes

### DIFF
--- a/B9PartSwitch/B9PartSwitch.csproj
+++ b/B9PartSwitch/B9PartSwitch.csproj
@@ -46,6 +46,9 @@
     <Reference Include="UnityEngine.CoreModule">
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="UnityEngine.UI">
       <Private>False</Private>
     </Reference>

--- a/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
+++ b/B9PartSwitch/PartSwitch/PartSwitchFlightDialog.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using B9PartSwitch.UI;
+using UnityEngine;
+using UnityEngine.UI;
 
 namespace B9PartSwitch
 {
@@ -104,7 +106,28 @@ namespace B9PartSwitch
 
             options.Add(new DialogGUIButton(Localization.PartSwitchFlightDialog_CancelString, delegate { } ));
 
-            return options.ToArray();
+            const float buttonHeight = 35;
+            if (buttonHeight * options.Count < 0.75f * Screen.height) return options.ToArray();
+
+            // UnityEngine.TextRenderingModule must be added to project References
+            options.Insert(0, new DialogGUIContentSizer(ContentSizeFitter.FitMode.Unconstrained, ContentSizeFitter.FitMode.PreferredSize));
+            DialogGUIBase[] scrollList = {
+                new DialogGUIContentSizer(ContentSizeFitter.FitMode.Unconstrained, ContentSizeFitter.FitMode.PreferredSize),
+                new DialogGUIScrollList(
+                    new Vector2(1, 0.75f * Screen.height),
+                    false,
+                    true,
+                    new DialogGUIVerticalLayout(
+                        true,
+                        true,
+                        4,
+                        new RectOffset(6, 24, 10, 10),
+                        TextAnchor.MiddleCenter,
+                        options.ToArray()
+                    )
+                )
+            };
+            return scrollList;
         }
     }
 }

--- a/B9PartSwitch/UI/UIPartActionSubtypeSelector.cs
+++ b/B9PartSwitch/UI/UIPartActionSubtypeSelector.cs
@@ -111,6 +111,21 @@ namespace B9PartSwitch.UI
             subtypeTitleText.text = switcherModule.CurrentSubtype.title;
 
             subtypeButtons[currentButtonIndex].Activate();
+
+            // up to 7 subtypeButtons fit in the PAW without scrolling
+            if (subtypeButtons.Count > 7)
+            {
+                scrollMain.scrollSensitivity = subtypeButtons.Count;
+                // scrollMain.horizontalNormalizedPosition is the left edge of the viewport relative to the content.
+                // scrollMain.viewport.rect.width will be 200+(2/3) units after layout stuff is finished.  Sadly, it is 0 when this code runs so we can't make use of it here.
+                // Each button is effectively 28 units wide, meaning the viewport is 7+(1/6) buttons wide.
+                // If we scroll past the last button, the buttons will bounce back so that the last button is touching the viewport's right edge.
+                // That bounce could make a player lose their place in the button list (plus it just looks bad).  Therefore, we don't use 1.0 to set the viewport full right.
+                const float viewportWidthInButtons = 7+1/6f;
+                if (currentButtonIndex < 4) scrollMain.horizontalNormalizedPosition = 0f;
+                else if (subtypeButtons.Count - currentButtonIndex < 5) scrollMain.horizontalNormalizedPosition = (subtypeButtons.Count - viewportWidthInButtons) / subtypeButtons.Count;
+                else scrollMain.horizontalNormalizedPosition = (currentButtonIndex + 4 - viewportWidthInButtons) / subtypeButtons.Count;
+            }
         }
 
         private void PreviousSubtype()


### PR DESCRIPTION
If there's anything you don't like or want me to change, I'm happy to fix it.

I think this is mostly relevant for Conformal Decals. https://github.com/blowfishpro/B9PartSwitch/issues/199  With a big atlas texture, 50+ (or even 100+) subtypes is not outside the realm of possibility.

The popup selector is unchanged if it fits nicely on screen:
![B9PS_0](https://user-images.githubusercontent.com/11653155/156649070-3e0fde3d-b936-4484-b595-0e4dd671aea3.png)

But if it would be too tall, a scrolling version is used instead:
![B9PS_1+2](https://user-images.githubusercontent.com/11653155/156649124-8e3990e6-c8f5-4109-ba70-2603ff95753c.png)

The in-PAW selector now scrolls automatically to keep the current subtype button visible.  The selected button will be centered unless it's too near the start/end of the list.  I also boost the scroll sensitivity according to the number of buttons, for people who prefer mouse-wheeling to dragging their way through a long list.
![B9PS_3](https://user-images.githubusercontent.com/11653155/156649179-c92e6d69-e5c6-4a00-bbe5-1ccbec1a43c2.png)
