### PR TITLE
Fix bug in MaybeAddModifier preventing maxTemp changes from being displayed

### DIFF
--- a/B9PartSwitch/PartSwitch/PartSubtype.cs
+++ b/B9PartSwitch/PartSwitch/PartSubtype.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UniLinq;
 using UnityEngine;
@@ -295,7 +295,7 @@ namespace B9PartSwitch
 
                 if (modifier is IPartAspectLock partAspectLockHolder)
                 {
-                    object partAspectLock = partAspectLockHolder;
+                    object partAspectLock = partAspectLockHolder.PartAspectLock;
                     if (aspectLocksOnOtherModules.Contains(partAspectLock))
                     {
                         OnInitializationError($"More than one module can't manage {modifier.Description}");


### PR DESCRIPTION
`MaybeAddModifier` added an object to the list instead of the field in the object. This prevented `maxTemp`, `skinMaxTemp` and `crashTolerance` from being displayed in the tooltip of switches.